### PR TITLE
Add MonadCatch instance for STM

### DIFF
--- a/io-sim/src/Control/Monad/IOSim/STM.hs
+++ b/io-sim/src/Control/Monad/IOSim/STM.hs
@@ -22,7 +22,7 @@ newtype TQueueDefault m a = TQueue (TVar m ([a], [a]))
 labelTQueueDefault
   :: MonadLabelledSTM m
   => TQueueDefault m a -> String -> STM m ()
-labelTQueueDefault (TQueue queue) label =  labelTVar queue label
+labelTQueueDefault (TQueue queue) =  labelTVar queue
 
 traceTQueueDefault
   :: MonadTraceSTM m

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -1212,6 +1212,18 @@ execAtomically time tid tlbl nextVid0 action0 k0 =
         -- TODO: step
         return $ SimPORTrace time tid (-1) tlbl (EventLog x) trace
 
+      CatchStm action' handler k ->
+        {-# SCC "execAtomically.go.CatchStm" #-} do
+        undefined
+
+      GetMaskStateStm x ->
+        {-# SCC "execAtomically.go.GetMaskStateStm" #-} do
+        undefined
+
+      SetMaskStateStm x m k ->
+        {-# SCC "execAtomically.go.SetMaskStateStm" #-} do
+        undefined
+
       where
         localInvariant =
             Map.keysSet written


### PR DESCRIPTION
- Add MonadCatch, MonadMask and Exception.MonadCatch interface for the STM.
- Add relevant entries for the StmA DSL.