### PR TITLE
STM instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# Circa 2022.10.03 (pre release)
+
+- Added `Semigroup` and `Monoid` instances for `STM` and `WrappedSTM` monads
+- Added `MArray` instance for `WrappedSTM` monad
+- Added `MonadFix` instance for `STM`
+
 # Circa 2022.09.27 (pre release)
 
 - Module structure of `MonadSTM` changed to follow `stm` package structure.

--- a/io-classes/src/Control/Monad/Class/MonadSTM/Internal.hs
+++ b/io-classes/src/Control/Monad/Class/MonadSTM/Internal.hs
@@ -1319,6 +1319,12 @@ deriving instance MonadSTM m => Monad       (WrappedSTM t r m)
 deriving instance MonadSTM m => Alternative (WrappedSTM t r m)
 deriving instance MonadSTM m => MonadPlus   (WrappedSTM t r m)
 
+instance ( Semigroup a, MonadSTM m ) => Semigroup (WrappedSTM t r m a) where
+    a <> b = (<>) <$> a <*> b
+instance ( Monoid a , MonadSTM m ) => Monoid (WrappedSTM t r m a) where
+    mempty = pure mempty
+
+
 -- note: this (and the following) instance requires 'UndecidableInstances'
 -- extension because it violates 3rd Paterson condition, however `STM m` will
 -- resolve to a concrete type of kind (Type -> Type), and thus no larger than

--- a/io-classes/src/Control/Monad/Class/MonadSTM/Internal.hs
+++ b/io-classes/src/Control/Monad/Class/MonadSTM/Internal.hs
@@ -1321,8 +1321,14 @@ deriving instance MonadSTM m => MonadPlus   (WrappedSTM t r m)
 
 instance ( Semigroup a, MonadSTM m ) => Semigroup (WrappedSTM t r m a) where
     a <> b = (<>) <$> a <*> b
-instance ( Monoid a , MonadSTM m ) => Monoid (WrappedSTM t r m a) where
+instance ( Monoid a, MonadSTM m )    => Monoid (WrappedSTM t r m a) where
     mempty = pure mempty
+
+instance ( MonadSTM m, MArray e a (STM m) ) => MArray e a (WrappedSTM t r m) where
+    getBounds         = WrappedSTM . getBounds
+    getNumElements    = WrappedSTM . getNumElements
+    unsafeRead arr    = WrappedSTM . unsafeRead arr
+    unsafeWrite arr i = WrappedSTM . unsafeWrite arr i
 
 
 -- note: this (and the following) instance requires 'UndecidableInstances'

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -1008,6 +1008,19 @@ execAtomically !time !tid !tlbl !nextVid0 action0 k0 =
         trace <- go ctl read written writtenSeq createdSeq nextVid k
         return $ SimTrace time tid tlbl (EventLog x) trace
 
+      LiftSTStm st k ->
+        {-# SCC "schedule.LiftSTStm" #-} do
+        x <- strictToLazyST st
+        go ctl read written writtenSeq createdSeq nextVid (k x)
+
+      FixStm f k ->
+        {-# SCC "execAtomically.go.FixStm" #-} do
+        r <- newSTRef (throw NonTermination)
+        x <- unsafeInterleaveST $ readSTRef r
+        let k' = unSTM (f x) $ \x' ->
+                    LiftSTStm (lazyToStrictST (writeSTRef r x')) (\() -> k x')
+        go ctl read written writtenSeq createdSeq nextVid k'
+
       where
         localInvariant =
             Map.keysSet written

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -205,6 +205,9 @@ data StmA s a where
                -> (Maybe a -> a -> ST s TraceValue)
                -> StmA s b -> StmA s b
 
+  LiftSTStm    :: StrictST.ST s a -> (a -> StmA s b) -> StmA s b
+  FixStm       :: (x -> STM s x) -> (x -> StmA s r) -> StmA s r
+
 -- Exported type
 type STMSim = STM
 
@@ -296,6 +299,9 @@ instance Alternative (STM s) where
     (<|>) = MonadSTM.orElse
 
 instance MonadPlus (STM s) where
+
+instance MonadFix (STM s) where
+    mfix f = STM $ oneShot $ \k -> FixStm f k
 
 instance MonadSay (IOSim s) where
   say msg = IOSim $ oneShot $ \k -> Say msg (k ())

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -178,6 +178,12 @@ data SimA s a where
 
 newtype STM s a = STM { unSTM :: forall r. (a -> StmA s r) -> StmA s r }
 
+instance Semigroup a => Semigroup (STM s a) where
+    a <> b = (<>) <$> a <*> b
+
+instance Monoid a => Monoid (STM s a) where
+    mempty = pure mempty
+
 runSTM :: STM s a -> StmA s a
 runSTM (STM k) = k ReturnStm
 


### PR DESCRIPTION
Fixes #30,
Fixes #31.

- monad-stm: added Semigroup and Monoid instances
- monad-stm: added missing MArray instance
- monad-stm: MonadFix instance
