### PR TITLE
Bump versions

### DIFF
--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -1,5 +1,5 @@
 name:                io-classes
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            Type classes for concurrency with STM, ST and timing
 -- description:
 license:             Apache-2.0

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -50,7 +50,7 @@ library
                        ScopedTypeVariables,
                        TypeFamilies
   build-depends:       base              >=4.9 && <4.18,
-                       io-classes        >=0.2 && <0.3,
+                       io-classes        ^>=0.3,
                        exceptions        >=0.10,
                        containers,
                        deque,
@@ -90,7 +90,7 @@ test-suite test
                        io-sim,
                        parallel,
                        QuickCheck,
-                       strict-stm,
+                       strict-stm ^>= 0.2,
                        tasty,
                        tasty-quickcheck,
                        tasty-hunit,

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.4
 name:                io-sim
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            A pure simulator for monadic concurrency with STM
 -- description:
 license:             Apache-2.0

--- a/strict-stm/strict-stm.cabal
+++ b/strict-stm/strict-stm.cabal
@@ -1,3 +1,4 @@
+cabal-version:       2.0
 name:                strict-stm
 version:             0.2.0.0
 synopsis:            Strict STM interface polymorphic over stm implementation.
@@ -13,7 +14,6 @@ author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
 maintainer:
 category:            Control
 build-type:          Simple
-cabal-version:       >=1.10
 tested-with:         GHC == 8.10.7, GHC == 9.2.4
 
 source-repository head
@@ -43,10 +43,10 @@ library
                        Control.Concurrent.Class.MonadSTM.Strict.TVar
   reexported-modules: Control.Concurrent.Class.MonadSTM.TSem as Control.Concurrent.Class.MonadSTM.Strict.TSem
   default-language:    Haskell2010
-  build-depends:       base  >=4.9 && <4.18,
+  build-depends:       base        >= 4.9 && <4.18,
                        array,
-                       stm   >=2.5 && <2.6,
-                       io-classes
+                       stm         >= 2.5 && <2.6,
+                       io-classes ^>= 0.3
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -Wcompat

--- a/strict-stm/strict-stm.cabal
+++ b/strict-stm/strict-stm.cabal
@@ -1,5 +1,5 @@
 name:                strict-stm
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            Strict STM interface polymorphic over stm implementation.
 description:         The `strict-stm` package gives a strict interface to stm,
                      currently either one provided by `stm` package for the


### PR DESCRIPTION
We're moving towards using [CHaP](https://github.com/input-output-hk/cardano-haskell-packages) for our Haskell packages. 

I am in the process of moving the ouroboros-network repository away from using source-repository-packages and towards using CHaP for its dependencies.

In input-output-hk/ouroboros-network#4047 ouroboros-network has moved to a version of io-sim newer than what's available in CHaP (commit f4183f274d88d0ad15817c7052df3a6a8b40e6dc, see [meta.toml](https://github.com/input-output-hk/cardano-haskell-packages/blob/main/_sources/io-sim/0.2.0.0/meta.toml)).

Would it be ok to bump the versions of the packages in this repository so I can "release" them to CHaP (and we'll talk more about how this goes in future) and get ouroboros-network to work?