### PR TITLE
Removed benchmarks which are based on typed-protocols

### DIFF
--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -110,9 +110,6 @@ benchmark bench
                        contra-tracer,
                        io-classes,
                        io-sim,
-                       typed-protocols >= 0.1.0.2,
-                       typed-protocols-cborg,
-                       typed-protocols-examples
   ghc-options:         -Wall
                        -Wcompat
                        -Wincomplete-uni-patterns


### PR DESCRIPTION
They made a dependency loop between `io-sim` and `typed-protocols`
making it harder than necessary to release a new version.

They were not micro benchmarks anyway.
