### PR TITLE
Build with ghc-9.4.4

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.5", "9.4.3"]
+        ghc: ["8.10.7", "9.2.5", "9.4.4"]
+        cabal: ["3.8.1.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     defaults:
@@ -42,7 +43,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.6.2.0
+        cabal-version: ${{ matrix.cabal }}
 
     - name: "WIN: Setup Haskell"
       id: win-setup-haskell
@@ -54,7 +55,7 @@ jobs:
           BOOTSTRAP_HASKELL_ADJUST_CABAL_CONFIG=1 \
           BOOTSTRAP_HASKELL_ADJUST_BASHRC=1 \
           BOOTSTRAP_HASKELL_GHC_VERSION="${{ matrix.ghc }}" \
-          BOOTSTRAP_HASKELL_CABAL_VERSION="3.6.2.0" \
+          BOOTSTRAP_HASKELL_CABAL_VERSION="${{ matrix.cabal }}" \
           sh
 
         # MSYS2 doesn't inherit $GITHUB_PATH so this is needed
@@ -142,7 +143,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: 8.10.7
-        cabal-version: 3.6.2.0
+        cabal-version: 3.8.1.0
 
     - name: "Setup cabal bin path"
       run: |


### PR DESCRIPTION
Use `cabal-3.8.1.0`.

Fixes #51.