### PR TITLE
Fix build badge in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Haskell CI](https://img.shields.io/github/workflow/status/input-output-hk/io-sim/Haskell%20CI?label=Build&style=for-the-badge)](https://github.com/input-output-hk/io-sim/actions/workflows/haskell.yml)
+[![Haskell CI](https://img.shields.io/github/actions/workflow/status/input-output-hk/io-sim/haskell.yml?label=Build&style=for-the-badge)](https://github.com/input-output-hk/io-sim/actions/workflows/haskell.yml)
 [![handbook](https://img.shields.io/badge/policy-Cardano%20Engineering%20Handbook-informational?style=for-the-badge)](https://input-output-hk.github.io/cardano-engineering-handbook)
 
 # io-sim


### PR DESCRIPTION
https://github.com/badges/shields/issues/8671 changed the URL for the badge we were using to show build status in the README. This PR updates the badge URL, such that the README shows up-to-date build information again.