### PR TITLE
Update copyright to 2023

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,8 @@
 name: Haskell CI
 
 on:
+  push:
+    branches: ["main"]
   pull_request:
 
 jobs:
@@ -142,7 +144,7 @@ jobs:
       uses: haskell/actions/setup@v1
       id: setup-haskell
       with:
-        ghc-version: 8.10.7
+        ghc-version: 9.2.5
         cabal-version: 3.8.1.0
 
     - name: "Setup cabal bin path"
@@ -156,7 +158,7 @@ jobs:
         key: cache-dependencies-${{ env.CACHE_VERSION }}
 
     - name: "Install `stylish-haskell`"
-      run: cabal install stylish-haskell-0.14.3.0
+      run: cabal install stylish-haskell-0.14.4.0
 
     - name: "`stylish-haskell` version"
       run: |

--- a/io-classes/NOTICE
+++ b/io-classes/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019 Input Output (Hong Kong) Ltd.
+Copyright 2019-2023 Input Output (Hong Kong) Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -6,7 +6,7 @@ license:             Apache-2.0
 license-files:
   LICENSE
   NOTICE
-copyright:           2019 Input Output (Hong Kong) Ltd.
+copyright:           2019-2023 Input Output (Hong Kong) Ltd.
 author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
 maintainer:
 category:            Control

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -12,7 +12,7 @@ maintainer:
 category:            Control
 build-type:          Simple
 cabal-version:       >=1.10
-tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.3
+tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.4
 
 source-repository head
   type:     git

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -6,7 +6,7 @@ license:             Apache-2.0
 license-files:
   LICENSE
   NOTICE
-copyright:           2019-2023 Input Output (Hong Kong) Ltd.
+copyright:           2019-2023 Input Output Global Inc (IOG)
 author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
 maintainer:
 category:            Control

--- a/io-sim/NOTICE
+++ b/io-sim/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019-2020 Input Output (Hong Kong) Ltd.
+Copyright 2019-2023 Input Output (Hong Kong) Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/io-sim/NOTICE
+++ b/io-sim/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019-2023 Input Output (Hong Kong) Ltd.
+Copyright 2019-2023 Input Output Global Inc (IOG)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -7,7 +7,7 @@ license:             Apache-2.0
 license-files:
   LICENSE
   NOTICE
-copyright:           2019-2023 Input Output (Hong Kong) Ltd.
+copyright:           2019-2023 Input Output Global Inc (IOG)
 author:              Duncan Coutts, Marcin Szamotulski, Alexander Vieth
 maintainer:
 category:            Testing

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -7,7 +7,7 @@ license:             Apache-2.0
 license-files:
   LICENSE
   NOTICE
-copyright:           2019-2020 Input Output (Hong Kong) Ltd.
+copyright:           2019-2023 Input Output (Hong Kong) Ltd.
 author:              Duncan Coutts, Marcin Szamotulski, Alexander Vieth
 maintainer:
 category:            Testing

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -12,7 +12,7 @@ author:              Duncan Coutts, Marcin Szamotulski, Alexander Vieth
 maintainer:
 category:            Testing
 build-type:          Simple
-tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.3
+tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.4
 
 flag asserts
   description: Enable assertions

--- a/strict-stm/NOTICE
+++ b/strict-stm/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019-2022 Input Output (Hong Kong) Ltd.
+Copyright 2019-2023 Input Output (Hong Kong) Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/strict-stm/NOTICE
+++ b/strict-stm/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019-2023 Input Output (Hong Kong) Ltd.
+Copyright 2019-2023 Input Output Global Inc (IOG)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/strict-stm/strict-stm.cabal
+++ b/strict-stm/strict-stm.cabal
@@ -9,7 +9,7 @@ license:             Apache-2.0
 license-files:
   LICENSE
   NOTICE
-copyright:           2019-2023 Input Output (Hong Kong) Ltd.
+copyright:           2019-2023 Input Output Global Inc (IOG)
 author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
 maintainer:
 category:            Control

--- a/strict-stm/strict-stm.cabal
+++ b/strict-stm/strict-stm.cabal
@@ -14,7 +14,7 @@ author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
 maintainer:
 category:            Control
 build-type:          Simple
-tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.3
+tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.4
 
 source-repository head
   type:     git

--- a/strict-stm/strict-stm.cabal
+++ b/strict-stm/strict-stm.cabal
@@ -9,7 +9,7 @@ license:             Apache-2.0
 license-files:
   LICENSE
   NOTICE
-copyright:           2019-2021 Input Output (Hong Kong) Ltd.
+copyright:           2019-2023 Input Output (Hong Kong) Ltd.
 author:              Alexander Vieth, Marcin Szamotulski, Duncan Coutts
 maintainer:
 category:            Control


### PR DESCRIPTION
The copyright info in `*.cabal` and `NOTICE` files is outdated. This PR also makes some small updates to the GitHub actions workflow file and `tested-with` entries in `*.cabal` files.