### PR TITLE
Strict MVars without invariant checking

### DIFF
--- a/.github/workflows/cabal.project.local
+++ b/.github/workflows/cabal.project.local
@@ -6,6 +6,10 @@ package io-classes
   ghc-options: -Werror
   flags: +asserts
 
+package strict-mvar
+  ghc-options: -Werror
+  flags: +asserts
+
 package strict-stm
   ghc-options: -Werror
   flags: +asserts

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -115,8 +115,7 @@ jobs:
 
     - name: Build dependencies
       run: |
-        cabal build --only-dependencies io-sim
-        cabal build --only-dependencies io-classes
+        cabal build --only-dependencies all
 
     - name: Build projects [build]
       run: cabal build all

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,24 @@
-dist-newstyle
+# Haskell
+dist
+dist-*
+cabal-dev
+*.o
+*.hi
+*.hie
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
+.stack-work/
+cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*

--- a/cabal.project
+++ b/cabal.project
@@ -16,12 +16,16 @@ index-state:
 
 packages: ./io-sim
           ./io-classes
+          ./strict-mvar
           ./strict-stm
 
 package io-sim
   flags: +asserts
 
 package io-classes
+  flags: +asserts
+
+package strict-mvar
   flags: +asserts
 
 package strict-stm

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -16,7 +16,7 @@ tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.4
 
 source-repository head
   type:     git
-  location: https://github.com/input-output-hk/ouroboros-network
+  location: https://github.com/input-output-hk/io-sim
   subdir:   io-classes
 
 flag asserts

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -21,7 +21,7 @@ flag asserts
 
 source-repository head
   type:     git
-  location: https://github.com/input-output-hk/ouroboros-network
+  location: https://github.com/input-output-hk/io-sim
   subdir:   io-sim
 
 library

--- a/scripts/check-stylish.sh
+++ b/scripts/check-stylish.sh
@@ -7,4 +7,5 @@ export LC_ALL=C.UTF-8
 
 $FD -E Setup.hs -g '*.hsc?$' io-sim -X stylish-haskell -c .stylish-haskell.yaml -i
 $FD -E Setup.hs -E src/Control/Concurrent/Class/MonadSTM.hs -g '*.hsc?$' io-classes -X stylish-haskell -c .stylish-haskell.yaml -i
+$FD -E Setup.hs -g '*.hsc?$' strict-mvar -X stylish-haskell -c .stylish-haskell.yaml -i
 $FD -E Setup.hs -g '*.hsc?$' strict-stm -X stylish-haskell -c .stylish-haskell.yaml -i

--- a/strict-mvar/CHANGELOG.md
+++ b/strict-mvar/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Revsion history of strict-mvar
+
+## 0.1.0.0
+
+* Initial version, not released on Hackage.

--- a/strict-mvar/LICENSE
+++ b/strict-mvar/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/strict-mvar/NOTICE
+++ b/strict-mvar/NOTICE
@@ -1,0 +1,14 @@
+Copyright 2019-2023 Input Output Global Inc (IOG).
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/strict-mvar/README.md
+++ b/strict-mvar/README.md
@@ -1,0 +1,7 @@
+# Strict mutable variables
+
+The `strict-mvar` package provides a strict interface to mutable variables
+(`MVar`). It builds on top of `io-classes`, and thus it provides the interface
+for `MVar`s implementations from both
+[base](https://hackage.haskell.org/package/base-4.17.0.0/docs/Control-Concurrent-MVar.html)
+and [io-sim](https://github.com/input-output-hk/io-sim).

--- a/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
+++ b/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | This module corresponds to 'Control.Concurrent.MVar' in "base" package
+--
+module Control.Concurrent.Class.MonadMVar.Strict
+  ( -- * StrictMVar
+    StrictMVar
+  , castStrictMVar
+  , toLazyMVar
+  , fromLazyMVar
+  , newEmptyMVar
+  , newMVar
+  , takeMVar
+  , putMVar
+  , readMVar
+  , swapMVar
+  , tryTakeMVar
+  , tryPutMVar
+  , isEmptyMVar
+  , withMVar
+  , withMVarMasked
+  , modifyMVar_
+  , modifyMVar
+  , modifyMVarMasked_
+  , modifyMVarMasked
+  , tryReadMVar
+  ) where
+
+import           Control.Monad.Class.MonadMVar (MonadMVar)
+import qualified Control.Monad.Class.MonadMVar as Lazy
+
+--
+-- StrictMVar
+--
+
+type LazyMVar m = Lazy.MVar m
+
+newtype StrictMVar m a = StrictMVar {
+    mvar      :: LazyMVar m a
+  }
+
+castStrictMVar :: LazyMVar m ~ LazyMVar n
+               => StrictMVar m a -> StrictMVar n a
+castStrictMVar v = StrictMVar (mvar v)
+
+-- | Get the underlying @MVar@
+--
+-- Since we obviously cannot guarantee that updates to this 'LazyMVar' will be
+-- strict, this should be used with caution.
+toLazyMVar :: StrictMVar m a -> LazyMVar m a
+toLazyMVar = mvar
+
+-- | Create a 'StrictMVar' from a 'LazyMVar'
+--
+-- It is not guaranteed that the 'LazyMVar' contains a value that is in WHNF, so
+-- there is no guarantee that the resulting 'StrictMVar' contains a value that
+-- is in WHNF. This should be used with caution.
+fromLazyMVar :: Lazy.MVar m a -> StrictMVar m a
+fromLazyMVar = StrictMVar
+
+newEmptyMVar :: MonadMVar m => m (StrictMVar m a)
+newEmptyMVar = fromLazyMVar <$> Lazy.newEmptyMVar
+
+newMVar :: MonadMVar m => a -> m (StrictMVar m a)
+newMVar !a = fromLazyMVar <$> Lazy.newMVar a
+
+takeMVar :: MonadMVar m => StrictMVar m a -> m a
+takeMVar = Lazy.takeMVar . mvar
+
+putMVar :: MonadMVar m => StrictMVar m a -> a -> m ()
+putMVar v !a = Lazy.putMVar (mvar v) a
+
+readMVar :: MonadMVar m => StrictMVar m a -> m a
+readMVar v = Lazy.readMVar (mvar v)
+
+swapMVar :: MonadMVar m => StrictMVar m a -> a -> m a
+swapMVar v !a = Lazy.swapMVar (mvar v) a
+
+tryTakeMVar :: MonadMVar m => StrictMVar m a -> m (Maybe a)
+tryTakeMVar v = Lazy.tryTakeMVar (mvar v)
+
+tryPutMVar :: MonadMVar m => StrictMVar m a -> a -> m Bool
+tryPutMVar v !a = Lazy.tryPutMVar (mvar v) a
+
+isEmptyMVar :: MonadMVar m => StrictMVar m a -> m Bool
+isEmptyMVar v = Lazy.isEmptyMVar (mvar v)
+
+withMVar :: MonadMVar m => StrictMVar m a -> (a -> m b) -> m b
+withMVar v io = Lazy.withMVar (mvar v) io'
+  where
+    io' a = do
+      !b <- io a
+      pure b
+
+withMVarMasked :: MonadMVar m => StrictMVar m a -> (a -> m b) -> m b
+withMVarMasked v io = Lazy.withMVarMasked (mvar v) io'
+  where
+    io' a = do
+      !b <- io a
+      pure b
+
+modifyMVar_ :: MonadMVar m => StrictMVar m a -> (a -> m a) -> m ()
+modifyMVar_ v io = Lazy.modifyMVar_ (mvar v) io'
+  where
+    io' a = do
+      !a' <- io a
+      pure a'
+
+modifyMVar :: MonadMVar m => StrictMVar m a -> (a -> m (a, b)) -> m b
+modifyMVar v io = Lazy.modifyMVar (mvar v) io'
+  where
+    io' a = do
+      (!a', b) <- io a
+      pure (a', b)
+
+modifyMVarMasked_ :: MonadMVar m => StrictMVar m a -> (a -> m a) -> m ()
+modifyMVarMasked_ v io = Lazy.modifyMVarMasked_ (mvar v) io'
+  where
+    io' a = do
+      !a' <- io a
+      pure a'
+
+modifyMVarMasked :: MonadMVar m => StrictMVar m a -> (a -> m (a,b)) -> m b
+modifyMVarMasked v io = Lazy.modifyMVarMasked (mvar v) io'
+  where
+    io' a = do
+      (!a', b) <- io a
+      pure (a', b)
+
+tryReadMVar :: MonadMVar m => StrictMVar m a -> m (Maybe a)
+tryReadMVar v = Lazy.tryReadMVar (mvar v)

--- a/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
+++ b/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
@@ -26,6 +26,8 @@ module Control.Concurrent.Class.MonadMVar.Strict
   , modifyMVarMasked_
   , modifyMVarMasked
   , tryReadMVar
+    -- * Re-exports
+  , MonadMVar
   ) where
 
 import           Control.Monad.Class.MonadMVar (MonadMVar)

--- a/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
+++ b/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
@@ -90,18 +90,10 @@ isEmptyMVar :: MonadMVar m => StrictMVar m a -> m Bool
 isEmptyMVar v = Lazy.isEmptyMVar (mvar v)
 
 withMVar :: MonadMVar m => StrictMVar m a -> (a -> m b) -> m b
-withMVar v io = Lazy.withMVar (mvar v) io'
-  where
-    io' a = do
-      !b <- io a
-      pure b
+withMVar v = Lazy.withMVar (mvar v)
 
 withMVarMasked :: MonadMVar m => StrictMVar m a -> (a -> m b) -> m b
-withMVarMasked v io = Lazy.withMVarMasked (mvar v) io'
-  where
-    io' a = do
-      !b <- io a
-      pure b
+withMVarMasked v = Lazy.withMVarMasked (mvar v)
 
 modifyMVar_ :: MonadMVar m => StrictMVar m a -> (a -> m a) -> m ()
 modifyMVar_ v io = Lazy.modifyMVar_ (mvar v) io'

--- a/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
+++ b/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | This module corresponds to 'Control.Concurrent.MVar' in "base" package
 --

--- a/strict-mvar/strict-mvar.cabal
+++ b/strict-mvar/strict-mvar.cabal
@@ -1,0 +1,43 @@
+cabal-version:       2.0
+name:                strict-mvar
+version:             0.1.0.0
+synopsis:            Strict MVars for `IO` and `io-sim`
+description:         Strict MVars for `IO` and `io-sim`.
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+copyright:           2019-2023 Input Output Global Inc (IOG).
+author:              IOHK Engineering Team
+maintainer:          operations@iohk.io
+category:            Control
+build-type:          Simple
+tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.3
+
+source-repository head
+  type:     git
+  location: https://github.com/input-output-hk/ouroboros-network
+  subdir:   strict-mvar
+
+flag asserts
+  description: Enable assertions
+  manual:      False
+  default:     False
+
+library
+  hs-source-dirs:      src
+
+  exposed-modules:     Control.Concurrent.Class.MonadMVar.Strict
+  default-language:    Haskell2010
+  build-depends:       base        >= 4.9 && <4.18,
+                       io-classes  >= 0.3 && <0.5
+  ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts

--- a/strict-mvar/strict-mvar.cabal
+++ b/strict-mvar/strict-mvar.cabal
@@ -1,8 +1,8 @@
 cabal-version:       3.0
 name:                strict-mvar
 version:             0.1.0.0
-synopsis:            Strict MVars for `IO` and `io-sim`
-description:         Strict MVars for `IO` and `io-sim`.
+synopsis:            Strict MVars for implementations of the `io-classes` MVar interface
+description:         Strict MVars for implementations of the `io-classes` MVar interface.
 license:             Apache-2.0
 license-files:
   LICENSE
@@ -12,7 +12,7 @@ author:              IOHK Engineering Team
 maintainer:          operations@iohk.io
 category:            Control
 build-type:          Simple
-tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.3
+tested-with:         GHC == { 8.10.7, 9.2.5, 9.4.4 }
 
 source-repository head
   type:     git
@@ -30,7 +30,7 @@ library
   exposed-modules:     Control.Concurrent.Class.MonadMVar.Strict
   default-language:    Haskell2010
   build-depends:       base        >= 4.9 && <4.18,
-                       io-classes  >= 0.3 && <0.5
+                       io-classes  >= 0.3 && <0.6
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -Wcompat

--- a/strict-mvar/strict-mvar.cabal
+++ b/strict-mvar/strict-mvar.cabal
@@ -1,4 +1,4 @@
-cabal-version:       2.0
+cabal-version:       3.0
 name:                strict-mvar
 version:             0.1.0.0
 synopsis:            Strict MVars for `IO` and `io-sim`
@@ -16,7 +16,7 @@ tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.3
 
 source-repository head
   type:     git
-  location: https://github.com/input-output-hk/ouroboros-network
+  location: https://github.com/input-output-hk/io-sim
   subdir:   strict-mvar
 
 flag asserts

--- a/strict-stm/README.md
+++ b/strict-stm/README.md
@@ -3,7 +3,7 @@
 The `strict-stm` package provides a strict interface to software transaction
 memory.  It builds on top of `io-classes` and thus it provides the interface
 for both [STM](https://hackage.haskell.org/package/stm) as well as
-[io-sim](https://github.com/input-output-hk/ouroboros-network/tree/master/io-classes).
+[io-sim](https://github.com/input-output-hk/io-sim).
 
 # Novel testing / space-leak elimination approach
 

--- a/strict-stm/strict-stm.cabal
+++ b/strict-stm/strict-stm.cabal
@@ -18,7 +18,7 @@ tested-with:         GHC == 8.10.7, GHC == 9.2.5, GHC == 9.4.4
 
 source-repository head
   type:     git
-  location: https://github.com/input-output-hk/ouroboros-network
+  location: https://github.com/input-output-hk/io-sim
   subdir:   strict-stm
 
 flag checktvarinvariant


### PR DESCRIPTION
This PR provides a new `strict-mvar` packages that implements strict MVars without invariant checking. Strict MVars are implemented in a fairly straightforward way by wrapping lazy MVars and forcing evaluation to WHNF before placing values in the lazy MVar.

@dcoutts suggested that strict MVars with invariant checking should be provided separately from MVars without invariant checking. As such, this PR only provides the latter.