### PR TITLE
Strict MVars with invariant checking

### DIFF
--- a/.github/workflows/cabal.project.local
+++ b/.github/workflows/cabal.project.local
@@ -8,7 +8,7 @@ package io-classes
 
 package strict-mvar
   ghc-options: -Werror
-  flags: +asserts
+  flags: +asserts +checkmvarinvariant
 
 package strict-stm
   ghc-options: -Werror

--- a/.github/workflows/cabal.project.local
+++ b/.github/workflows/cabal.project.local
@@ -8,7 +8,6 @@ package io-classes
 
 package strict-mvar
   ghc-options: -Werror
-  flags: +asserts +checkmvarinvariant
 
 package strict-stm
   ghc-options: -Werror

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -127,6 +127,9 @@ jobs:
     - name: si-timers [test]
       run: cabal run si-timers:test
 
+    - name: strict-mvar [test]
+      run: cabal run strict-mvar:test
+
   stylish-haskell:
     runs-on: ubuntu-22.04
 

--- a/cabal.project
+++ b/cabal.project
@@ -31,8 +31,5 @@ package io-sim
 package io-classes
   flags: +asserts
 
-package strict-mvar
-  flags: +asserts
-
 package strict-stm
   flags: +asserts

--- a/strict-mvar/CHANGELOG.md
+++ b/strict-mvar/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Revsion history of strict-mvar
 
+## next version
+
+### Breaking changes
+
+* Remove the `asserts` package flag.
+
+### Non breaking changes
+
+* Add a `StrictMVar` with invariant checking in
+  `Control.Concurrent.Class.MonadMVar.Strict.Checked`.
+* Make the checked/unchecked `StrictMVar` modules drop-in replacements of one
+  another by unifying the interfaces. As a result,
+  `Control.Concurrent.Class.MonadMVar.Strict` now has `newMVarWithInvariant` and
+  `newEmptyMVarWithInvariant` functions that ignore the invariant argument.
+
 ## 1.1.0.0
 
 ### Non breaking changes

--- a/strict-mvar/README.md
+++ b/strict-mvar/README.md
@@ -45,6 +45,7 @@ are distinct types.
 Although all functions that modify a checked `StrictMVar` will check the
 invariant, we do *not* guarantee that the value inside the `StrictMVar` always
 satisfies the invariant. Instead, we *do* guarantee that if the `StrictMVar` is
-updated with a value that does not satisfy the invariant, an exception is
-thrown. The reason for this weaker guarantee is that leaving an `MVar` empty can
-lead to very hard to debug "blocked indefinitely" problems.
+updated with a value that does not satisfy the invariant, an exception is thrown
+*after* the new value is written to the `StrictMVar`. The reason for this weaker
+guarantee is that leaving an `MVar` empty can lead to very hard to debug
+"blocked indefinitely" problems.

--- a/strict-mvar/README.md
+++ b/strict-mvar/README.md
@@ -5,3 +5,46 @@ The `strict-mvar` package provides a strict interface to mutable variables
 for `MVar`s implementations from both
 [base](https://hackage.haskell.org/package/base-4.17.0.0/docs/Control-Concurrent-MVar.html)
 and [io-sim](https://github.com/input-output-hk/io-sim).
+
+## Checked and unchecked `StrictMVar`s
+
+There are currently two variant implementations of `StrictMVar`s in this package:
+* `Control.Concurrent.Class.MonadMVar.Strict`
+* `Control.Concurrent.Class.MonadMVar.Strict.Checked`
+
+The _unchecked_ module provides the simplest implementation of a `StrictMVar`: a
+light wrapper around lazy MVars that forces values to WHNF before they are put
+into the MVar. The _checked_ module does the exact same thing, but it has the
+additional feature that the user can provide an invariant that is checked each
+time a new value is placed inside the MVar. The two modules are drop-in
+replacements for one another: switching from `*.Strict` to `*.Strict.Checked`
+will enable invariant checking, while the converse will disable invariant
+checking. To facilitate drop-in replacement, both modules share the same
+interface, though in case of the `*.Strict` module, everything related to
+invariants will be ignored. This will be explicitly mentioned in the Haddock
+documentation of said definitions. For example:
+
+```haskell
+-- | The given invariant will never be checked. 'newMVarWithInvariant' is a
+-- light wrapper around 'newMVar', and is only included here to ensure that the
+-- current module and "Control.Concurrent.Class.MonadMVar.Strict.Checked" are
+-- drop-in replacements for one another.
+newMVarWithInvariant :: MonadMVar m
+                     => (a -> Maybe String)
+                     -> a
+                     -> m (StrictMVar m a)
+```
+
+**Note:** though the two modules are drop-in replacements for one another, the
+`StrictMVar` type from `*.Strict` and the `StrictMVar` type from
+`*.Strict.Checked` do not share the same internal representation, and so they
+are distinct types.
+
+## Guarantees for invariant checking
+
+Although all functions that modify a checked `StrictMVar` will check the
+invariant, we do *not* guarantee that the value inside the `StrictMVar` always
+satisfies the invariant. Instead, we *do* guarantee that if the `StrictMVar` is
+updated with a value that does not satisfy the invariant, an exception is
+thrown. The reason for this weaker guarantee is that leaving an `MVar` empty can
+lead to very hard to debug "blocked indefinitely" problems.

--- a/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
+++ b/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
@@ -2,16 +2,22 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 
--- | This module corresponds to 'Control.Concurrent.MVar' in "base" package
+-- | This module corresponds to "Control.Concurrent.MVar" in the @base@ package.
 --
+-- Use "Control.Concurrent.Class.MonadMVar.Strict.Checked" as a drop-in
+-- replacement for the current module in case you want to check invariants on
+-- the values inside 'StrictMVar's.
 module Control.Concurrent.Class.MonadMVar.Strict
   ( -- * StrictMVar
     StrictMVar
+  , LazyMVar
   , castStrictMVar
   , toLazyMVar
   , fromLazyMVar
   , newEmptyMVar
+  , newEmptyMVarWithInvariant
   , newMVar
+  , newMVarWithInvariant
   , takeMVar
   , putMVar
   , readMVar
@@ -65,8 +71,27 @@ fromLazyMVar = StrictMVar
 newEmptyMVar :: MonadMVar m => m (StrictMVar m a)
 newEmptyMVar = fromLazyMVar <$> Lazy.newEmptyMVar
 
+-- | The given invariant will never be checked. 'newEmptyMVarWithInvariant' is a
+-- light wrapper around 'newEmptyMVar', and is only included here to ensure that
+-- the current module and "Control.Concurrent.Class.MonadMVar.Strict.Checked"
+-- are drop-in replacements for one another.
+newEmptyMVarWithInvariant :: MonadMVar m
+                          => (a -> Maybe String)
+                          -> m (StrictMVar m a)
+newEmptyMVarWithInvariant _inv = StrictMVar <$> Lazy.newEmptyMVar
+
 newMVar :: MonadMVar m => a -> m (StrictMVar m a)
 newMVar !a = fromLazyMVar <$> Lazy.newMVar a
+
+-- | The given invariant will never be checked. 'newMVarWithInvariant' is a
+-- light wrapper around 'newMVar', and is only included here to ensure that the
+-- current module and "Control.Concurrent.Class.MonadMVar.Strict.Checked" are
+-- drop-in replacements for one another.
+newMVarWithInvariant :: MonadMVar m
+                     => (a -> Maybe String)
+                     -> a
+                     -> m (StrictMVar m a)
+newMVarWithInvariant _inv !a = StrictMVar <$> Lazy.newMVar a
 
 takeMVar :: MonadMVar m => StrictMVar m a -> m a
 takeMVar = Lazy.takeMVar . mvar

--- a/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
+++ b/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
@@ -1,0 +1,188 @@
+{-# LANGUAGE BangPatterns  #-}
+{-# LANGUAGE CPP           #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeFamilies  #-}
+{-# LANGUAGE TypeOperators #-}
+
+-- | This module corresponds to 'Control.Concurrent.MVar' in "base" package
+--
+module Control.Concurrent.Class.MonadMVar.Strict.Checked
+  ( -- * StrictMVar
+    StrictMVar
+  , castStrictMVar
+  , toLazyMVar
+  , fromLazyMVar
+  , newEmptyMVar
+  , newEmptyMVarWithInvariant
+  , newMVar
+  , newMVarWithInvariant
+  , takeMVar
+  , putMVar
+  , readMVar
+  , swapMVar
+  , tryTakeMVar
+  , tryPutMVar
+  , isEmptyMVar
+  , withMVar
+  , withMVarMasked
+  , modifyMVar_
+  , modifyMVar
+  , modifyMVarMasked_
+  , modifyMVarMasked
+  , tryReadMVar
+    -- * Re-exports
+  , MonadMVar
+  ) where
+
+import           Control.Concurrent.Class.MonadMVar (MonadMVar)
+import qualified Control.Concurrent.Class.MonadMVar as Lazy
+import           GHC.Stack (HasCallStack)
+
+--
+-- StrictMVar
+--
+
+type LazyMVar m = Lazy.MVar m
+
+-- | A strict MVar with invariant checking.
+--
+-- There is a weaker invariant for a 'StrictMVar' than for a 'StrictTVar' (see
+-- the @strict-stm@ package): although all functions that modify the
+-- 'StrictMVar' check the invariant, we do /not/ guarantee that the value inside
+-- the 'StrictMVar' always satisfies the invariant. Instead, we /do/ guarantee
+-- that if the 'StrictMVar' is updated with a value that does not satisfy the
+-- invariant, an exception is thrown. The reason for this weaker guarantee is
+-- that leaving an 'MVar' empty can lead to very hard to debug "blocked
+-- indefinitely" problems.
+data StrictMVar m a = StrictMVar {
+    -- | The invariant that is checked whenever the 'StrictMVar' is updated.
+    invariant :: !(a -> Maybe String)
+  , mvar      :: !(LazyMVar m a)
+  }
+
+castStrictMVar :: LazyMVar m ~ LazyMVar n
+               => StrictMVar m a -> StrictMVar n a
+castStrictMVar v = StrictMVar (invariant v) (mvar v)
+
+-- | Get the underlying @MVar@
+--
+-- Since we obviously can not guarantee that updates to this 'LazyMVar' will be
+-- strict, this should be used with caution.
+--
+-- Similarly, we can not guarantee that updates to this 'LazyMVar' do not break
+-- the original invariant that the 'StrictMVar' held.
+toLazyMVar :: StrictMVar m a -> LazyMVar m a
+toLazyMVar = mvar
+
+-- | Create a 'StrictMVar' from a 'LazyMVar'
+--
+-- It is not guaranteed that the 'LazyMVar' contains a value that is in WHNF, so
+-- there is no guarantee that the resulting 'StrictMVar' contains a value that
+-- is in WHNF. This should be used with caution.
+--
+-- The resulting 'StrictMVar' has a trivial invariant.
+fromLazyMVar :: Lazy.MVar m a -> StrictMVar m a
+fromLazyMVar = StrictMVar (const Nothing)
+
+newEmptyMVar :: MonadMVar m => m (StrictMVar m a)
+newEmptyMVar = fromLazyMVar <$> Lazy.newEmptyMVar
+
+newEmptyMVarWithInvariant ::
+     MonadMVar m
+  => (a -> Maybe String) -> m (StrictMVar m a)
+newEmptyMVarWithInvariant inv = StrictMVar inv <$> Lazy.newEmptyMVar
+
+newMVar :: MonadMVar m => a -> m (StrictMVar m a)
+newMVar !a = fromLazyMVar <$> Lazy.newMVar a
+
+newMVarWithInvariant ::
+     MonadMVar m
+  => (a -> Maybe String) -> a -> m (StrictMVar m a)
+newMVarWithInvariant inv !a =
+  checkInvariant (inv a) $
+  StrictMVar inv <$> Lazy.newMVar a
+
+takeMVar :: MonadMVar m => StrictMVar m a -> m a
+takeMVar = Lazy.takeMVar . mvar
+
+putMVar :: MonadMVar m => StrictMVar m a -> a -> m ()
+putMVar v !a = do
+  Lazy.putMVar (mvar v) a
+  checkInvariant (invariant v a) $ pure ()
+
+readMVar :: MonadMVar m => StrictMVar m a -> m a
+readMVar v = Lazy.readMVar (mvar v)
+
+swapMVar :: MonadMVar m => StrictMVar m a -> a -> m a
+swapMVar v !a = do
+  oldValue <- Lazy.swapMVar (mvar v) a
+  checkInvariant (invariant v a) $ pure oldValue
+
+tryTakeMVar :: MonadMVar m => StrictMVar m a -> m (Maybe a)
+tryTakeMVar v = Lazy.tryTakeMVar (mvar v)
+
+tryPutMVar :: MonadMVar m => StrictMVar m a -> a -> m Bool
+tryPutMVar v !a = do
+  didPut <- Lazy.tryPutMVar (mvar v) a
+  checkInvariant (invariant v a) $ pure didPut
+
+isEmptyMVar :: MonadMVar m => StrictMVar m a -> m Bool
+isEmptyMVar v = Lazy.isEmptyMVar (mvar v)
+
+withMVar :: MonadMVar m => StrictMVar m a -> (a -> m b) -> m b
+withMVar v = Lazy.withMVar (mvar v)
+
+withMVarMasked :: MonadMVar m => StrictMVar m a -> (a -> m b) -> m b
+withMVarMasked v = Lazy.withMVarMasked (mvar v)
+
+-- | 'modifyMVar_' is defined in terms of 'modifyMVar'.
+modifyMVar_ :: MonadMVar m => StrictMVar m a -> (a -> m a) -> m ()
+modifyMVar_ v io = modifyMVar v io'
+  where io' a = (,()) <$> io a
+
+modifyMVar :: MonadMVar m => StrictMVar m a -> (a -> m (a,b)) -> m b
+modifyMVar v io = do
+    (a', b) <- Lazy.modifyMVar (mvar v) io'
+    checkInvariant (invariant v a') $ pure b
+  where
+    io' a = do
+      (!a', b) <- io a
+      -- Returning @a'@ along with @b@ allows us to check the invariant /after/
+      -- filling in the MVar.
+      pure (a' , (a', b))
+
+-- | 'modifyMVarMasked_' is defined in terms of 'modifyMVarMasked'.
+modifyMVarMasked_ :: MonadMVar m => StrictMVar m a -> (a -> m a) -> m ()
+modifyMVarMasked_ v io = modifyMVar v io'
+  where io' a = (,()) <$> io a
+
+modifyMVarMasked :: MonadMVar m => StrictMVar m a -> (a -> m (a,b)) -> m b
+modifyMVarMasked v io = do
+    (a', b) <- Lazy.modifyMVar (mvar v) io'
+    checkInvariant (invariant v a') $ pure b
+  where
+    io' a = do
+      (!a', b) <- io a
+      -- Returning @a'@ along with @b@ allows us to check the invariant /after/
+      -- filling in the MVar.
+      pure (a', (a', b))
+
+tryReadMVar :: MonadMVar m => StrictMVar m a -> m (Maybe a)
+tryReadMVar v = Lazy.tryReadMVar (mvar v)
+
+--
+-- Dealing with invariants
+--
+
+-- | Check invariant (if enabled)
+--
+-- @checkInvariant mErr x@ is equal to @x@ if @mErr == Nothing@, and throws an
+-- error @err@ if @mErr == Just err@.
+checkInvariant :: HasCallStack => Maybe String -> a -> a
+
+#if CHECK_MVAR_INVARIANT
+checkInvariant Nothing    k = k
+checkInvariant (Just err) _ = error $ "Invariant violation: " ++ err
+#else
+checkInvariant _err       k = k
+#endif

--- a/strict-mvar/strict-mvar.cabal
+++ b/strict-mvar/strict-mvar.cabal
@@ -24,16 +24,6 @@ source-repository head
   location: https://github.com/input-output-hk/io-sim
   subdir:   strict-mvar
 
-flag checkmvarinvariant
-  Description: Enable runtime invariant checks on StrictMVar
-  Manual: True
-  Default: False
-
-flag asserts
-  description: Enable assertions
-  manual:      False
-  default:     False
-
 library
   hs-source-dirs:      src
 
@@ -49,12 +39,6 @@ library
                        -Wincomplete-record-updates
                        -Wpartial-fields
                        -Widentities
-
-  if flag(asserts)
-    ghc-options: -fno-ignore-asserts
-
-  if flag(checkmvarinvariant)
-    cpp-options: -DCHECK_MVAR_INVARIANT
 
 test-suite test
   type:                exitcode-stdio-1.0

--- a/strict-mvar/strict-mvar.cabal
+++ b/strict-mvar/strict-mvar.cabal
@@ -47,7 +47,7 @@ test-suite test
 
   other-modules:       Test.Control.Concurrent.Class.MonadMVar.Strict.Checked
   default-language:    Haskell2010
-  build-depends:       base >=4.9 && <4.18,
+  build-depends:       base >=4.9 && <4.19,
                        QuickCheck,
                        tasty,
                        tasty-quickcheck,

--- a/strict-mvar/strict-mvar.cabal
+++ b/strict-mvar/strict-mvar.cabal
@@ -48,6 +48,7 @@ test-suite test
   other-modules:       Test.Control.Concurrent.Class.MonadMVar.Strict.Checked
   default-language:    Haskell2010
   build-depends:       base >=4.9 && <4.19,
+                       io-sim,
                        QuickCheck,
                        tasty,
                        tasty-quickcheck,

--- a/strict-mvar/strict-mvar.cabal
+++ b/strict-mvar/strict-mvar.cabal
@@ -24,6 +24,11 @@ source-repository head
   location: https://github.com/input-output-hk/io-sim
   subdir:   strict-mvar
 
+flag checkmvarinvariant
+  Description: Enable runtime invariant checks on StrictMVar
+  Manual: True
+  Default: False
+
 flag asserts
   description: Enable assertions
   manual:      False
@@ -33,6 +38,7 @@ library
   hs-source-dirs:      src
 
   exposed-modules:     Control.Concurrent.Class.MonadMVar.Strict
+                     , Control.Concurrent.Class.MonadMVar.Strict.Checked
   default-language:    Haskell2010
   build-depends:       base        >= 4.9 && <4.19,
                        io-classes  >= 1.0 && <1.2
@@ -46,3 +52,28 @@ library
 
   if flag(asserts)
     ghc-options: -fno-ignore-asserts
+
+  if flag(checkmvarinvariant)
+    cpp-options: -DCHECK_MVAR_INVARIANT
+
+test-suite test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Main.hs
+
+  other-modules:       Test.Control.Concurrent.Class.MonadMVar.Strict.Checked
+  default-language:    Haskell2010
+  build-depends:       base >=4.9 && <4.18,
+                       QuickCheck,
+                       tasty,
+                       tasty-quickcheck,
+                       strict-mvar,
+
+  ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -fno-ignore-asserts

--- a/strict-mvar/test/Main.hs
+++ b/strict-mvar/test/Main.hs
@@ -1,0 +1,22 @@
+module Main where
+
+import qualified Test.Control.Concurrent.Class.MonadMVar.Strict.Checked as Checked
+import           Test.Tasty
+
+main :: IO ()
+main = defaultMain $
+    testGroup "Test" [
+        testGroup "Control" [
+            testGroup "Concurrent" [
+                testGroup "Class" [
+                    testGroup "MonadMVar" [
+                        testGroup "Strict" [
+                            testGroup "Checked" [
+                                Checked.tests
+                              ]
+                          ]
+                      ]
+                  ]
+              ]
+          ]
+      ]

--- a/strict-mvar/test/Main.hs
+++ b/strict-mvar/test/Main.hs
@@ -4,19 +4,4 @@ import qualified Test.Control.Concurrent.Class.MonadMVar.Strict.Checked as Check
 import           Test.Tasty
 
 main :: IO ()
-main = defaultMain $
-    testGroup "Test" [
-        testGroup "Control" [
-            testGroup "Concurrent" [
-                testGroup "Class" [
-                    testGroup "MonadMVar" [
-                        testGroup "Strict" [
-                            testGroup "Checked" [
-                                Checked.tests
-                              ]
-                          ]
-                      ]
-                  ]
-              ]
-          ]
-      ]
+main = defaultMain Checked.tests

--- a/strict-mvar/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
+++ b/strict-mvar/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
@@ -1,6 +1,10 @@
+{-# LANGUAGE RankNTypes #-}
+
 module Test.Control.Concurrent.Class.MonadMVar.Strict.Checked where
 
 import           Control.Concurrent.Class.MonadMVar.Strict.Checked
+import           Control.Monad.IOSim
+import           Test.QuickCheck.Gen.Unsafe (Capture (..), capture)
 import           Test.QuickCheck.Monadic
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -8,8 +12,18 @@ import           Test.Tasty.QuickCheck
 tests :: TestTree
 tests = testGroup "Test.Control.Concurrent.Class.MonadMVar.Strict" [
       testGroup "Checked" [
-          testProperty "prop_invariantShouldFail" prop_invariantShouldFail
-        , testProperty "prop_invariantShouldNotFail" prop_invariantShouldNotFail
+          testGroup "IO" [
+              testProperty "prop_invariantShouldFail" $
+                once $ expectFailure $ monadicIO prop_invariantShouldFail
+            , testProperty "prop_invariantShouldNotFail" $
+                once                 $ monadicIO prop_invariantShouldNotFail
+            ]
+        , testGroup "IOSim" [
+              testProperty "prop_invariantShouldFail" $
+                once $ expectFailure $ monadicSim prop_invariantShouldFail
+            , testProperty "prop_invariantShouldNotFail" $
+                once                 $ monadicSim prop_invariantShouldNotFail
+            ]
         ]
     ]
 
@@ -19,12 +33,24 @@ invPositiveInt x
   | x >= 0    = Nothing
   | otherwise = Just $ "x<0 for x=" <> show x
 
-prop_invariantShouldFail :: Property
-prop_invariantShouldFail = once $ expectFailure $ monadicIO $ run $ do
+prop_invariantShouldNotFail :: MonadMVar m => PropertyM m ()
+prop_invariantShouldNotFail = run $ do
+    v <- newMVarWithInvariant invPositiveInt 0
+    modifyMVar_ v (\x -> pure $ x + 1)
+
+prop_invariantShouldFail :: MonadMVar m => PropertyM m ()
+prop_invariantShouldFail = run $ do
     v <- newMVarWithInvariant invPositiveInt 0
     modifyMVar_ v (\x -> pure $ x - 1)
 
-prop_invariantShouldNotFail :: Property
-prop_invariantShouldNotFail = monadicIO $ run $ do
-    v <- newMVarWithInvariant invPositiveInt 0
-    modifyMVar_ v (\x -> pure $ x + 1)
+{-------------------------------------------------------------------------------
+  Property runners (copied from "Ouroboros.Network.Testing.QuickCheck")
+-------------------------------------------------------------------------------}
+
+runSimGen :: (forall s. Gen (IOSim s a)) -> Gen a
+runSimGen f = do
+    Capture eval <- capture
+    return $ runSimOrThrow (eval f)
+
+monadicSim :: Testable a => (forall s. PropertyM (IOSim s) a) -> Property
+monadicSim m = property (runSimGen (monadic' m))

--- a/strict-mvar/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
+++ b/strict-mvar/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
@@ -1,5 +1,3 @@
--- | Tests in this module depend on the @+checkmvarinvariant@ flag being
--- enabled.
 module Test.Control.Concurrent.Class.MonadMVar.Strict.Checked where
 
 import           Control.Concurrent.Class.MonadMVar.Strict.Checked
@@ -8,10 +6,12 @@ import           Test.Tasty
 import           Test.Tasty.QuickCheck
 
 tests :: TestTree
-tests = testGroup "Checked" [
-    testProperty "prop_invariantShouldFail" prop_invariantShouldFail
-  , testProperty "prop_invariantShouldNotFail" prop_invariantShouldNotFail
-  ]
+tests = testGroup "Test.Control.Concurrent.Class.MonadMVar.Strict" [
+      testGroup "Checked" [
+          testProperty "prop_invariantShouldFail" prop_invariantShouldFail
+        , testProperty "prop_invariantShouldNotFail" prop_invariantShouldNotFail
+        ]
+    ]
 
 -- | Invariant that checks whether an @Int@ is positive.
 invPositiveInt :: Int -> Maybe String
@@ -23,10 +23,8 @@ prop_invariantShouldFail :: Property
 prop_invariantShouldFail = once $ expectFailure $ monadicIO $ run $ do
     v <- newMVarWithInvariant invPositiveInt 0
     modifyMVar_ v (\x -> pure $ x - 1)
-    pure ()
 
 prop_invariantShouldNotFail :: Property
 prop_invariantShouldNotFail = monadicIO $ run $ do
     v <- newMVarWithInvariant invPositiveInt 0
     modifyMVar_ v (\x -> pure $ x + 1)
-    pure ()

--- a/strict-mvar/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
+++ b/strict-mvar/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
@@ -1,0 +1,32 @@
+-- | Tests in this module depend on the @+checkmvarinvariant@ flag being
+-- enabled.
+module Test.Control.Concurrent.Class.MonadMVar.Strict.Checked where
+
+import           Control.Concurrent.Class.MonadMVar.Strict.Checked
+import           Test.QuickCheck.Monadic
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Checked" [
+    testProperty "prop_invariantShouldFail" prop_invariantShouldFail
+  , testProperty "prop_invariantShouldNotFail" prop_invariantShouldNotFail
+  ]
+
+-- | Invariant that checks whether an @Int@ is positive.
+invPositiveInt :: Int -> Maybe String
+invPositiveInt x
+  | x >= 0    = Nothing
+  | otherwise = Just $ "x<0 for x=" <> show x
+
+prop_invariantShouldFail :: Property
+prop_invariantShouldFail = once $ expectFailure $ monadicIO $ run $ do
+    v <- newMVarWithInvariant invPositiveInt 0
+    modifyMVar_ v (\x -> pure $ x - 1)
+    pure ()
+
+prop_invariantShouldNotFail :: Property
+prop_invariantShouldNotFail = monadicIO $ run $ do
+    v <- newMVarWithInvariant invPositiveInt 0
+    modifyMVar_ v (\x -> pure $ x + 1)
+    pure ()


### PR DESCRIPTION
Part of #34.

#72 provided a new strict-mvar packages that implements strict MVars without invariant checking. This is a follow-up PR that adds strict MVars *with* invariant checking in a separate module in the `strict-mvar` package.