### PR TITLE
Fix issue #76

### DIFF
--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -666,7 +666,6 @@ schedule thread@Thread{
                          <> readEffects read
                          <> writeEffects written
                          <> wakeupEffects unblocked
-                         <> statusWriteEffects unblocked
               thread'     = thread { threadControl = ThreadControl (k x) ctl,
                                      threadVClock  = vClock',
                                      threadEffect  = effect' }
@@ -713,6 +712,7 @@ schedule thread@Thread{
           vids <- traverse (\(SomeTVar tvar) -> labelledTVarId tvar) read
           vClockRead <- leastUpperBoundTVarVClocks read
           let effect' = effect <> readEffects read
+                               <> statusWriteEffects [tid]
               thread' = thread { threadVClock  = vClock `leastUpperBoundVClock` vClockRead,
                                  threadEffect  = effect' }
           !trace <- deschedule Blocked thread' simstate

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -626,7 +626,6 @@ schedule thread@Thread{
                               threadEffect  = effect
                                            <> forkEffect tid'
                                            <> statusWriteEffect tid'
-                                           <> statusWriteEffect tid
                               }
           thread'' = Thread { threadId      = tid'
                             , threadControl = ThreadControl (runIOSim a)

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -594,7 +594,6 @@ schedule thread@Thread{
       let effect' = effect
                  <> writeEffects written
                  <> wakeupEffects wakeup
-                 <> statusWriteEffects unblocked
           thread' = thread { threadControl = ThreadControl k ctl
                            , threadEffect  = effect'
                            }

--- a/io-sim/src/Control/Monad/IOSimPOR/Types.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Types.hs
@@ -64,8 +64,17 @@ statusWriteEffects tids = mempty{effectStatusWrites = tids}
 someTvarId :: SomeTVar s -> TVarId
 someTvarId (SomeTVar r) = tvarId r
 
+-- | Make sure we only have read effects
+--
+-- We ignore `effectStatusReads` and `effectStatusWrites`. This is because
+-- effects of `threadStatus` are non-blocking, if they block it is a result of
+-- of a blocking stm transaction.
+--
 onlyReadEffect :: Effect -> Bool
-onlyReadEffect e = e { effectReads = effectReads mempty } == mempty
+onlyReadEffect e = e { effectReads        = effectReads mempty
+                     , effectStatusReads  = effectStatusReads mempty
+                     , effectStatusWrites = effectStatusWrites mempty
+                     } == mempty
 
 racingEffects :: Effect -> Effect -> Bool
 racingEffects e e' =

--- a/io-sim/src/Control/Monad/IOSimPOR/Types.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Types.hs
@@ -82,9 +82,11 @@ racingEffects e e' =
    || effectReads  e       `intersects`  effectWrites e'
    || effectWrites e       `intersects`  effectReads  e'
    || effectWrites e       `intersects`  effectWrites e'
-   || effectStatusReads e  `intersectsL` effectStatusWrites e'
-   || effectStatusWrites e `intersectsL` effectStatusReads  e'
-   || effectStatusWrites e `intersectsL` effectStatusWrites e'
+   {--
+     - || effectStatusReads e  `intersectsL` effectStatusWrites e'
+     - || effectStatusWrites e `intersectsL` effectStatusReads  e'
+     - || effectStatusWrites e `intersectsL` effectStatusWrites e'
+     --}
   where
     intersects :: Ord a => Set a -> Set a -> Bool
     intersects a b = not $ a `Set.disjoint` b

--- a/io-sim/test/Test/Control/Monad/IOSimPOR.hs
+++ b/io-sim/test/Test/Control/Monad/IOSimPOR.hs
@@ -49,6 +49,7 @@ tests =
   testGroup "IO simulator POR"
   [ testProperty "propSimulates"    propSimulates
   , testProperty "propExploration"  propExploration
+  , testProperty "unit 76"          prop_unit_76
   -- , testProperty "propPermutations" propPermutations
   , testGroup "IO simulator properties"
     [ testProperty "read/write graph (IOSim)" (withMaxSuccess 1000 prop_stm_graph_sim)
@@ -374,6 +375,17 @@ traceNoDuplicates k = r `pseq` (k addTrace .&&. maximum (traceCounts ()) == 1)
 -- IOSim reused properties
 --
 
+-- propExploration unit tests
+--
+prop_unit_76 :: Property
+prop_unit_76 =
+  propExploration (Tasks [Task [WhenSet 9 0],Task [WhenSet 0 0],Task [WhenSet 10 10,WhenSet 10 9],Task [WhenSet 0 0]])
+  .&&.
+  propExploration (Tasks [Task [],Task [ThrowTo 4],Task [WhenSet 19 18,ThrowTo 0],Task [WhenSet 18 0,ThrowTo 2],Task [WhenSet 0 0]])
+  .&&.
+  propExploration (Tasks [Task [WhenSet 4 0],Task [WhenSet 0 0],Task [WhenSet 5 5,WhenSet 5 4],Task [WhenSet 0 0]])
+  .&&.
+  propExploration (Tasks [Task [WhenSet 4 0],Task [WhenSet 0 0],Task [WhenSet 5 5,WhenSet 5 4],Task [CheckStatus 0,WhenSet 0 0]])
 
 --
 -- Read/Write graph


### PR DESCRIPTION
Ignore effectStatusWrites in order to not generate bad schedules that lead to assertion failures.

Also fix issue introduced in 669d6b23c41d22f503916b7a924a11c39b442347 where the onlyReadEffect is not checking for effectStatusRead effects.

Check #76 for more details