### PR TITLE
Move `Control.Monad.Class.MonadMVar` to `Control.Concurrent.Class.MonadMVar`

### DIFF
--- a/io-classes/CHANGELOG.md
+++ b/io-classes/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revsion history of io-classes
 
+## Next version
+
+### Breaking changes
+
+* `Control.Monad.Class.MonadMVar` is now deprecated in favour of
+  `Control.Concurrent.Class.MonadMVar`.
+
 ## 1.0.0.1
 
 ### Non breaking changes

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -58,6 +58,7 @@ library
                        Control.Monad.Class.MonadAsync
                        Control.Monad.Class.MonadEventlog
                        Control.Monad.Class.MonadFork
+                       Control.Monad.Class.MonadMVar
                        Control.Monad.Class.MonadSay
                        Control.Monad.Class.MonadST
                        Control.Monad.Class.MonadSTM

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -46,7 +46,8 @@ library
 
   -- At this experiment/prototype stage everything is exposed.
   -- This has to be tidied up once the design becomes clear.
-  exposed-modules:     Control.Concurrent.Class.MonadSTM
+  exposed-modules:     Control.Concurrent.Class.MonadMVar
+                       Control.Concurrent.Class.MonadSTM
                        Control.Concurrent.Class.MonadSTM.TArray
                        Control.Concurrent.Class.MonadSTM.TBQueue
                        Control.Concurrent.Class.MonadSTM.TChan
@@ -57,7 +58,6 @@ library
                        Control.Monad.Class.MonadAsync
                        Control.Monad.Class.MonadEventlog
                        Control.Monad.Class.MonadFork
-                       Control.Monad.Class.MonadMVar
                        Control.Monad.Class.MonadSay
                        Control.Monad.Class.MonadST
                        Control.Monad.Class.MonadSTM

--- a/io-classes/src/Control/Concurrent/Class/MonadMVar.hs
+++ b/io-classes/src/Control/Concurrent/Class/MonadMVar.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE TypeOperators          #-}
 
-module Control.Monad.Class.MonadMVar (MonadMVar (..)) where
+module Control.Concurrent.Class.MonadMVar (MonadMVar (..)) where
 
 import qualified Control.Concurrent.MVar as IO
 import           Control.Monad.Class.MonadThrow

--- a/io-classes/src/Control/Monad/Class/MonadMVar.hs
+++ b/io-classes/src/Control/Monad/Class/MonadMVar.hs
@@ -1,0 +1,3 @@
+module Control.Monad.Class.MonadMVar {-# DEPRECATED "Use Control.Concurrent.Class.MonadMVar" #-} (module X) where
+
+import Control.Concurrent.Class.MonadMVar as X

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -98,11 +98,11 @@ test-suite test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Main.hs
-  other-modules:       Test.Control.Monad.STM
+  other-modules:       Test.Control.Concurrent.Class.MonadMVar
+                       Test.Control.Monad.STM
                        Test.Control.Monad.Utils
                        Test.Control.Monad.IOSim
                        Test.Control.Monad.IOSimPOR
-                       Test.Control.Monad.Class.MonadMVar
   default-language:    Haskell2010
   build-depends:       base,
                        array,

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -75,6 +75,7 @@ import           Control.Exception (ErrorCall (..), asyncExceptionFromException,
 import           Control.Monad
 import           Control.Monad.Fix (MonadFix (..))
 
+import           Control.Concurrent.Class.MonadMVar
 import           Control.Concurrent.Class.MonadSTM.Strict.TVar (StrictTVar)
 import qualified Control.Concurrent.Class.MonadSTM.Strict.TVar as StrictTVar
 import           Control.Monad.Class.MonadAsync hiding (Async)
@@ -82,7 +83,6 @@ import qualified Control.Monad.Class.MonadAsync as MonadAsync
 import           Control.Monad.Class.MonadEventlog
 import           Control.Monad.Class.MonadFork hiding (ThreadId)
 import qualified Control.Monad.Class.MonadFork as MonadFork
-import           Control.Monad.Class.MonadMVar
 import           Control.Monad.Class.MonadST
 import           Control.Monad.Class.MonadSTM.Internal (MonadInspectSTM (..),
                      MonadLabelledSTM (..), MonadSTM, MonadTraceSTM (..),
@@ -942,7 +942,7 @@ data SimEventType
                        [Labelled TVarId] -- ^ and created these
                        (Maybe Effect)    -- ^ effect performed (only for `IOSimPOR`)
   -- | aborted an STM transaction (by an exception)
-  -- 
+  --
   -- For /IOSimPOR/ it also holds performed effect.
   | EventTxAborted     (Maybe Effect)
   -- | STM transaction blocked (due to `retry`)
@@ -984,7 +984,7 @@ data SimEventType
   --
   -- threadStatus
   --
-  
+
   -- | event traced when `threadStatus` is executed
   | EventThreadStatus  ThreadId -- ^ current thread
                        ThreadId -- ^ queried thread

--- a/io-sim/test/Main.hs
+++ b/io-sim/test/Main.hs
@@ -2,7 +2,7 @@ module Main (main) where
 
 import           Test.Tasty
 
-import qualified Test.Control.Monad.Class.MonadMVar (tests)
+import qualified Test.Control.Concurrent.Class.MonadMVar (tests)
 import qualified Test.Control.Monad.IOSim (tests)
 import qualified Test.Control.Monad.IOSimPOR (tests)
 
@@ -12,7 +12,7 @@ main = defaultMain tests
 tests :: TestTree
 tests =
   testGroup "IO Sim"
-  [ Test.Control.Monad.Class.MonadMVar.tests
+  [ Test.Control.Concurrent.Class.MonadMVar.tests
   , Test.Control.Monad.IOSim.tests
   , Test.Control.Monad.IOSimPOR.tests
   ]

--- a/io-sim/test/Test/Control/Concurrent/Class/MonadMVar.hs
+++ b/io-sim/test/Test/Control/Concurrent/Class/MonadMVar.hs
@@ -3,11 +3,11 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections       #-}
 
-module Test.Control.Monad.Class.MonadMVar where
+module Test.Control.Concurrent.Class.MonadMVar where
 
+import           Control.Concurrent.Class.MonadMVar
 import           Control.Monad.Class.MonadAsync
 import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadMVar
 import           Control.Monad.Class.MonadTime.SI
 import           Control.Monad.Class.MonadTimer.SI
 import           Data.Bifoldable (bifoldMap)
@@ -25,7 +25,7 @@ import           Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests =
-    testGroup "Control.Monad.Class.MonadMVar"
+    testGroup "Control.Concurrent.Class.MonadMVar"
     [ testGroup "putMVar"
       [ testProperty "fairness (IOSim)" prop_putMVar_fairness_sim
       , testCase "blocks on a full MVar (IOSim)"

--- a/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
+++ b/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
@@ -30,8 +30,8 @@ module Control.Concurrent.Class.MonadMVar.Strict
   , MonadMVar
   ) where
 
-import           Control.Monad.Class.MonadMVar (MonadMVar)
-import qualified Control.Monad.Class.MonadMVar as Lazy
+import           Control.Concurrent.Class.MonadMVar (MonadMVar)
+import qualified Control.Concurrent.Class.MonadMVar as Lazy
 
 --
 -- StrictMVar


### PR DESCRIPTION
As suggested in https://github.com/input-output-hk/io-sim/pull/74#discussion_r1156071137, we move `Control.Monad.Class.MonadMVar` to `Control.Concurrent.Class.MonadMVar`, which is closer to what `base` uses in its module hierarchy (`Control.Concurrent.MVar`), and where `MonadSTM` lives (`Control.Concurrent.Class.MonadSTM`).

Question: should we leave deprecation warnings behind in the old modules? What is the general policy for deprecation in this repo?