### PR TITLE
Update GitHub actions workflow to use `ghc-9.2.7` instead of `ghc-9.2.5`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.5", "9.4.4"]
+        ghc: ["8.10.7", "9.2.7", "9.4.4"]
         cabal: ["3.8.1.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
@@ -146,7 +146,7 @@ jobs:
       uses: haskell/actions/setup@v1
       id: setup-haskell
       with:
-        ghc-version: 9.2.5
+        ghc-version: 9.2.7
         cabal-version: 3.8.1.0
 
     - name: "Setup cabal bin path"

--- a/strict-mvar/strict-mvar.cabal
+++ b/strict-mvar/strict-mvar.cabal
@@ -17,7 +17,7 @@ category:            Control
 build-type:          Simple
 extra-source-files:  CHANGELOG.md
                      README.md
-tested-with:         GHC == { 8.10.7, 9.2.5, 9.4.4 }
+tested-with:         GHC == { 8.10, 9.2, 9.4 }
 
 source-repository head
   type:     git


### PR DESCRIPTION
`ghc-9.2.7` is currently recommended, so I've replaced `ghc-9.2.5` by `ghc-9.2.7`