### PR TITLE
coot/ghc 8.10 fix

### DIFF
--- a/io-classes-mtl/io-classes-mtl.cabal
+++ b/io-classes-mtl/io-classes-mtl.cabal
@@ -46,7 +46,7 @@ library
                       array,
                       mtl,
 
-                      io-classes ^>= 1.0.0.0,
+                      io-classes  >= 1.0 && < 1.2,
                       si-timers,
 
 

--- a/io-classes/CHANGELOG.md
+++ b/io-classes/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Revsion history of io-classes
 
-## Next version
+## 1.1.0.0
 
 ### Breaking changes
 
 * `Control.Monad.Class.MonadMVar` is now deprecated in favour of
   `Control.Concurrent.Class.MonadMVar`.
+
+### Non breaking changes
+
+* Fixed building haddocks with `ghc-8.10`.
 
 ## 1.0.0.1
 

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                io-classes
-version:             1.0.0.1
+version:             1.1.0.0
 synopsis:            Type classes for concurrency with STM, ST and timing
 description:
   IO Monad class hierarchy compatible with

--- a/io-classes/src/Control/Monad/Class/MonadSTM/Internal.hs
+++ b/io-classes/src/Control/Monad/Class/MonadSTM/Internal.hs
@@ -99,12 +99,6 @@ module Control.Monad.Class.MonadSTM.Internal
   , labelTChanDefault
   ) where
 
--- $default-implementations
---
--- The default implementations are based on a `TVar` defined in the class.  They
--- are tailored towards `IOSim` rather than instances which would like to derive
--- from `IO` or monad transformers.
-
 import           Prelude hiding (read)
 
 import qualified Control.Concurrent.STM.TArray as STM
@@ -134,6 +128,13 @@ import           Data.Proxy (Proxy (..))
 import           Data.Typeable (Typeable)
 import           GHC.Stack
 import           Numeric.Natural (Natural)
+
+
+-- $default-implementations
+--
+-- The default implementations are based on a `TVar` defined in the class.  They
+-- are tailored towards `IOSim` rather than instances which would like to derive
+-- from `IO` or monad transformers.
 
 
 -- | The STM primitives parametrised by a monad `m`.

--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revsion history of io-sim
 
+## 1.1.0.0
+
+### Non breaking changes
+
+* `io-classes-1.1.0.0`
+
 ## 1.0.0.1
 
 ### Non breaking changes

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                io-sim
-version:             1.0.0.1
+version:             1.1.0.0
 synopsis:            A pure simulator for monadic concurrency with STM.
 description:
   A pure simulator monad with support of concurency (base, async), stm,
@@ -77,14 +77,14 @@ library
                        ScopedTypeVariables,
                        TypeFamilies
   build-depends:       base              >=4.9 && <4.19,
-                       io-classes       ^>=1.0,
+                       io-classes       ^>=1.1,
                        exceptions        >=0.10,
                        containers,
                        nothunks,
                        parallel,
                        psqueues          >=0.2 && <0.3,
-                       strict-stm       ^>=1.0,
-                       si-timers        ^>=1.0,
+                       strict-stm        >=1.0 && <1.2,
+                       si-timers         >=1.0 && <1.2,
                        time              >=1.9.1 && <1.13,
                        quiet,
                        QuickCheck,

--- a/si-timers/CHANGELOG.md
+++ b/si-timers/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.0.0
+
+### Non breaking changes
+
+* `io-classes-1.1.0.0`
+
 ## 1.0.0.1
 
 ### Non breaking changes

--- a/si-timers/si-timers.cabal
+++ b/si-timers/si-timers.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                si-timers
-version:             1.0.0.1
+version:             1.1.0.0
 synopsis:            timers using SI units (seconds)
 description:
   Timers using SI units (seconds) which are safe on 32-bit platforms and
@@ -59,7 +59,7 @@ library
                        stm,
                        time              >=1.9.1 && <1.13,
 
-                       io-classes       ^>=1.0
+                       io-classes        >=1.0 && <1.2
   if flag(asserts)
      ghc-options:      -fno-ignore-asserts
 

--- a/strict-mvar/CHANGELOG.md
+++ b/strict-mvar/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revsion history of strict-mvar
 
+## 1.1.0.0
+
+### Non breaking changes
+
+* `io-classes-1.1.0.0`
+
 ## 1.0.0.1
 
 ### Non breaking changes

--- a/strict-mvar/strict-mvar.cabal
+++ b/strict-mvar/strict-mvar.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                strict-mvar
-version:             1.0.0.1
+version:             1.1.0.0
 synopsis:            Strict MVars for IO and IOSim
 description:
   Strict @MVar@ interface compatible with
@@ -35,7 +35,7 @@ library
   exposed-modules:     Control.Concurrent.Class.MonadMVar.Strict
   default-language:    Haskell2010
   build-depends:       base        >= 4.9 && <4.19,
-                       io-classes ^>= 1.0
+                       io-classes  >= 1.0 && <1.2
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -Wcompat

--- a/strict-stm/CHANGELOG.md
+++ b/strict-stm/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## next version
+## 1.1.0.0
 
 ### Breaking changes
 
 * Removed deprecated API
+
+### Non breaking changes
+
+* `io-classes-1.1.0.0`
 
 ## 1.0.0.1
 

--- a/strict-stm/strict-stm.cabal
+++ b/strict-stm/strict-stm.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                strict-stm
-version:             1.0.0.1
+version:             1.1.0.0
 synopsis:            Strict STM interface polymorphic over stm implementation.
 description:
   Strict STM interface provided on top of
@@ -59,7 +59,7 @@ library
                        array,
                        stm         >= 2.5 && <2.6,
 
-                       io-classes  ^>= 1.0
+                       io-classes  >= 1.0 && <1.2
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
                        -Wcompat


### PR DESCRIPTION
- io-classes: fixed building haddocks with ghc-8.10
- version 1.1.0.0
