### PR TITLE
Build haddocks on CI

### DIFF
--- a/.github/workflows/cabal.project.local
+++ b/.github/workflows/cabal.project.local
@@ -1,4 +1,4 @@
-documentation: True
+documentation: False
 tests:         True
 benchmarks:    True
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -121,6 +121,9 @@ jobs:
     - name: Build projects [build]
       run: cabal build all
 
+    - name: Build documentation [haddock]
+      run: cabal haddock all
+
     - name: io-sim [test]
       run: cabal run io-sim:test
 


### PR DESCRIPTION
`cabal build` succeeds when haddock fails, use `cabal haddock` instead.
