### PR TITLE
strict-stm: Fix typo'd checktvarinvariant CPP flag

### DIFF
--- a/strict-stm/strict-stm.cabal
+++ b/strict-stm/strict-stm.cabal
@@ -70,4 +70,4 @@ library
     ghc-options: -fno-ignore-asserts
 
   if flag(checktvarinvariant)
-    cpp-options: -DCHECK_TVAR_INVARIAN
+    cpp-options: -DCHECK_TVAR_INVARIANT


### PR DESCRIPTION
Fixes the CPP flag being misnamed, causing the invariant checking code to never build