### PR TITLE
New `MonadInspectMVar` class

### DIFF
--- a/io-classes/CHANGELOG.md
+++ b/io-classes/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Revsion history of io-classes
 
+## next version
+
+### Non-breaking changes
+
+* Add new `MonadInspectMVar` class with an `inspectMVar` function for accessing
+  an `MVar` in an underlying monad (if applicable). This is mainly useful for
+  `io-sim`, since the underlying monad is `ST`. `IO` has no underlying monad, so
+  the provided instance for `IO` defaults `inspectMVar` to `tryReadMVar`.
+
 ## 1.1.0.0
 
 ### Breaking changes

--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revsion history of io-sim
 
+## next version
+
+### Non breaking changes
+
+* Provide `MonadInspectMVar` instance for `IOSim`.
+
 ## 1.1.0.0
 
 ### Non breaking changes

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -567,6 +567,14 @@ instance MonadMVar (IOSim s) where
   tryReadMVar  = tryReadMVarDefault
   isEmptyMVar  = isEmptyMVarDefault
 
+instance MonadInspectMVar (IOSim s) where
+  type InspectMVarMonad (IOSim s) = ST s
+  inspectMVar p (MVar tvar) = do
+      st <- inspectTVar p tvar
+      case st of
+        MVarEmpty _ _ -> pure Nothing
+        MVarFull x _  -> pure (Just x)
+
 data Async s a = Async !ThreadId (STM s (Either SomeException a))
 
 instance Eq (Async s a) where


### PR DESCRIPTION
Add a new `MonadInspectMVar` class (similar to `MonadInspectSTM`) with an `inspectMVar` function for accessing an `MVar` in an underlying monad (if applicable). This is mainly useful for `io-sim`, since the underlying monad is `ST`. `IO` has no underlying monad, so the provided instance for `IO` defaults `inspectMVar` to `tryReadMVar`.