### PR TITLE
Provide minimal haddock comments for MonadDelay

### DIFF
--- a/io-classes/CHANGELOG.md
+++ b/io-classes/CHANGELOG.md
@@ -9,6 +9,8 @@
   `io-sim`, since the underlying monad is `ST`. `IO` has no underlying monad, so
   the provided instance for `IO` defaults `inspectMVar` to `tryReadMVar`.
 
+* Add some Haddock documentation to `MonadDelay`
+
 ## 1.1.0.0
 
 ### Breaking changes

--- a/io-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies        #-}
 
+-- | Provides classes to handle delays and timeouts.
 module Control.Monad.Class.MonadTimer
   ( MonadDelay (..)
   , MonadTimer (..)
@@ -18,13 +19,22 @@ import           Control.Monad.Trans (lift)
 
 import qualified System.Timeout as IO
 
+-- | A typeclass to delay current thread.
 class Monad m => MonadDelay m where
+
+  -- | Suspends the current thread for a given number of microseconds
+  -- (GHC only).
+  --
+  -- See `IO.threadDelay`.
   threadDelay :: Int -> m ()
 
+-- | A typeclass providing utilities for /timeouts/.
 class (MonadDelay m, MonadSTM m) => MonadTimer m where
 
+  -- | See `STM.registerDelay`.
   registerDelay :: Int -> m (TVar m Bool)
 
+  -- | See `IO.timeout`.
   timeout :: Int -> m a -> m (Maybe a)
 
 --


### PR DESCRIPTION
I have spent some time figuring out why my code wasn't working anymore after I upgraded io-classes version, until I realised the threadDelay was not taking a DiffTime anymore but an Int as number of us.