### PR TITLE
Use ppSimResult in traceDebugLog

### DIFF
--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -6,9 +6,6 @@
 
 * `MainReturn`, `MainException` and the pattern synonyms `TraceMainReturn`,
   `TraceMainException` changed their signature.  They will now also show the main thread id.
-
-#### Breaking changes
-
 * Renamed `ThreadId` to `IOSimThreadId` to avoid a clash with `ThreadId`
   associated type family of `MonadFork`.  It makes it much simpler to paste
   failing `ScheduleControl` in `ghci` or tests.
@@ -17,7 +14,6 @@
   a constructor for internal failures.  This improved error reporting when
   there's a bug in `IOSimPOR`.  Currently it's only used by some of the
   assertions in `IOSimPOR`.
-* added pretty printer for `SimResult`, and other pretty printer improvements.
 
 #### Non breaking changes
 
@@ -37,6 +33,7 @@
 * Reimplemented `labelTVarIO` and `traceTVarIO` in `ST` monad, which simplifies
   trace of these calls.
 * Fixed `traceTVar` for `TVar`'s created with `registerDelay`.
+* Added pretty printer for `SimResult`, and other pretty printer improvements.
 
 ## 1.2.0.0
 

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -639,9 +639,9 @@ exploreSimTraceST optsf main k =
 traceDebugLog :: Int -> SimTrace a -> ST s ()
 traceDebugLog logLevel _trace | logLevel <= 0 = pure ()
 traceDebugLog 1 trace = Debug.traceM $ "Simulation trace with discovered schedules:\n"
-                                    ++ Trace.ppTrace show (ppSimEvent 0 0 0) (ignoreRaces $ void `first` trace)
+                                    ++ Trace.ppTrace (ppSimResult 0 0 0) (ppSimEvent 0 0 0) (ignoreRaces $ void `first` trace)
 traceDebugLog _ trace = Debug.traceM $ "Simulation trace with discovered schedules:\n"
-                                    ++ Trace.ppTrace show (ppSimEvent 0 0 0) (void `first` trace)
+                                    ++ Trace.ppTrace (ppSimResult 0 0 0) (ppSimEvent 0 0 0) (void `first` trace)
 
 
 -- | Run a simulation using a given schedule.  This is useful to reproduce

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -49,6 +49,7 @@ module Control.Monad.IOSim.Types
   , ppSimEventType
   , SimEvent (..)
   , SimResult (..)
+  , ppSimResult
   , SimTrace
   , Trace.Trace (SimTrace, SimPORTrace, TraceMainReturn, TraceMainException, TraceDeadlock, TraceRacesFound, TraceLoop, TraceInternalError)
   , ppTrace


### PR DESCRIPTION
Use `ppSimResult` in `traceDebugLog`, it's also exported from the
`Control.Monad.IOSim` module.
