### PR TITLE
Do not run GHA actions on main branch

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,8 +1,6 @@
 name: Cheks
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
   merge_group:
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,8 +1,6 @@
 name: Haskell CI
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
   merge_group:
 


### PR DESCRIPTION
There's no need, since we already run them in `merge_group`.
