### PR TITLE
io-{sim,classes} 1.4.1.0 release

### DIFF
--- a/.github/workflows/cabal.project.local
+++ b/.github/workflows/cabal.project.local
@@ -6,6 +6,9 @@ package io-classes
   ghc-options: -Werror
   flags: +asserts
 
+package io-classes-mtl
+  ghc-options: -Werror
+
 package strict-mvar
   ghc-options: -Werror
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,14 +46,15 @@ jobs:
         cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
         echo "weeknum=$(/bin/date -u "+%W")" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: "Cache cabal store"
       with:
         path: ${{ runner.os == 'Windows' && steps.win-setup-haskell.outputs.cabal-store || steps.setup-haskell.outputs.cabal-store }}
         key: cache-dependencies-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
         restore-keys: cache-dependencies-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
+        enableCrossOsArchive: true
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       name: "Cache `dist-newstyle`"
       with:
         path: |
@@ -61,6 +62,7 @@ jobs:
           !dist-newstyle/**/.git
         key: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ steps.record-deps.outputs.weeknum }}
         restore-keys: cache-dist-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
+        enableCrossOsArchive: true
 
     - name: Build dependencies
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -46,8 +46,8 @@ jobs:
         cat dist-newstyle/cache/plan.json | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
         echo "weeknum=$(/bin/date -u "+%W")" >> $GITHUB_OUTPUT
 
-    - uses: actions/cache@v4
-      name: "Cache cabal store"
+    - uses: actions/cache/restore@v4
+      name: "Restore cabal store"
       with:
         path: ${{ runner.os == 'Windows' && steps.win-setup-haskell.outputs.cabal-store || steps.setup-haskell.outputs.cabal-store }}
         key: cache-dependencies-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
@@ -67,6 +67,13 @@ jobs:
     - name: Build dependencies
       run: |
         cabal build --only-dependencies all
+
+    - uses: actions/cache/save@v4
+      name: "Save cabal store"
+      with:
+        path: ${{ runner.os == 'Windows' && steps.win-setup-haskell.outputs.cabal-store || steps.setup-haskell.outputs.cabal-store }}
+        key: cache-dependencies-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+        enableCrossOsArchive: true
 
     - name: Build projects [build]
       run: cabal build all

--- a/io-classes-mtl/CHANGELOG.md
+++ b/io-classes-mtl/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Revision history for io-classes-mtl
 
-## next release
+## 0.1.1.0
 
-### Breaking changes
-
-### Non-breaking changes
+* Support `io-classes-1.4.1.0`
 
 ## 0.1.0.2
 
@@ -16,6 +14,6 @@
 
 * Support `ghc-9.6`.
 
-## 0.1.0.0 -- YYYY-mm-dd
+## 0.1.0.0
 
 * First version. Released on an unsuspecting world.

--- a/io-classes-mtl/io-classes-mtl.cabal
+++ b/io-classes-mtl/io-classes-mtl.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               io-classes-mtl
-version:            0.1.0.3
+version:            0.1.1.0
 synopsis:           Experimental MTL instances for io-classes
 description:
     MTL instances for
@@ -44,7 +44,7 @@ library
                       array,
                       mtl,
 
-                      io-classes  >=1.0 && <1.5,
+                      io-classes ^>=1.4.1.0,
                       si-timers,
 
 

--- a/io-classes-mtl/src/Control/Monad/Class/MonadST/Trans.hs
+++ b/io-classes-mtl/src/Control/Monad/Class/MonadST/Trans.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-deprecations #-}
 module Control.Monad.Class.MonadST.Trans () where
 
 import           Control.Monad.Cont (ContT)

--- a/io-classes-mtl/src/Control/Monad/Class/MonadST/Trans.hs
+++ b/io-classes-mtl/src/Control/Monad/Class/MonadST/Trans.hs
@@ -15,25 +15,33 @@ import           Control.Monad.Class.MonadST
 
 
 instance MonadST m => MonadST (ContT r m) where
+  stToIO = lift . stToIO
   withLiftST f = withLiftST $ \g -> f (lift . g)
 
 instance MonadST m => MonadST (ExceptT e m) where
+  stToIO = lift . stToIO
   withLiftST f = withLiftST $ \g -> f (lift . g)
 
 instance (Monoid w, MonadST m) => MonadST (Lazy.RWST r w s m) where
+  stToIO = lift . stToIO
   withLiftST f = withLiftST $ \g -> f (lift . g)
 
 instance (Monoid w, MonadST m) => MonadST (Strict.RWST r w s m) where
+  stToIO = lift . stToIO
   withLiftST f = withLiftST $ \g -> f (lift . g)
 
 instance MonadST m => MonadST (Lazy.StateT s m) where
+  stToIO = lift . stToIO
   withLiftST f = withLiftST $ \g -> f (lift . g)
 
 instance MonadST m => MonadST (Strict.StateT s m) where
+  stToIO = lift . stToIO
   withLiftST f = withLiftST $ \g -> f (lift . g)
 
 instance (Monoid w, MonadST m) => MonadST (Lazy.WriterT w m) where
-   withLiftST f = withLiftST $ \g -> f (lift . g) 
+  stToIO = lift . stToIO
+  withLiftST f = withLiftST $ \g -> f (lift . g) 
 
 instance (Monoid w, MonadST m) => MonadST (Strict.WriterT w m) where
+  stToIO = lift . stToIO
   withLiftST f = withLiftST $ \g -> f (lift . g)

--- a/io-classes/CHANGELOG.md
+++ b/io-classes/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Revsion history of io-classes
 
-## next version (1.4.1.0)
+## 1.4.1.0
 
 ### Non-breaking changes
 
 * New dependency on `primitive` package
 * New `stToIO` in `MonadST`, which is simpler to use than the existing
-  `withLiftST`, and depends on the `primitive` package's `PrimState`.
+  `withLiftST`, and depends on the `primitive` package's `PrimState` (#141).
 
 ## 1.4.0.0
 

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                io-classes
-version:             1.4.0.0
+version:             1.4.1.0
 synopsis:            Type classes for concurrency with STM, ST and timing
 description:
   IO Monad class hierarchy compatible with

--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -1,15 +1,14 @@
 # Revsion history of io-sim
 
-## next version (1.4.1.0)
-
-* Prevent STM waking up threads blocked on `threadDelay`.
+## 1.4.1.0
 
 ### Non-breaking changes
 
-* QuickCheck monadic combinators: `monadicIOSim`, `monadicIOSim_` and `runIOSimGen`.
+* QuickCheck monadic combinators: `monadicIOSim`, `monadicIOSim_` and `runIOSimGen` (#140).
 * New dependency on `primitive`
 * Provides an instance for `PrimMonad`, giving access to most functionality
-  from the `primitive` package.
+  from the `primitive` package (#141).
+* Prevented STM waking up threads blocked on `threadDelay` (#142).
 
 ## 1.4.0.0
 

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                io-sim
-version:             1.4.0.0
+version:             1.4.1.0
 synopsis:            A pure simulator for monadic concurrency with STM.
 description:
   A pure simulator monad with support of concurency (base & async style), stm,
@@ -76,7 +76,7 @@ library
                        ScopedTypeVariables,
                        TypeFamilies
   build-depends:       base              >=4.9 && <4.20,
-                       io-classes        >=1.3 && <1.5,
+                       io-classes       ^>=1.4.1,
                        exceptions        >=0.10,
                        containers,
                        deepseq,


### PR DESCRIPTION
- Updated `io-classes-mtl`
- GHA: use enableCrossOsArchive to fix caching
- Bump versions of io-{sim,classes,classes-mtl}
