### PR TITLE
CI: Bump checkout to v4

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         sudo apt install -y fd-find
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: git fetch
       run: git fetch origin main:main
@@ -68,7 +68,7 @@ jobs:
         which stylish-haskell
         stylish-haskell --version
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: "Run `stylish-haskell`"
       run: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -48,7 +48,7 @@ jobs:
         echo "PATH = $PATH"
         echo "LLVM_CONFIG = $LLVM_CONFIG"
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: "Configure cabal.project.local"
       run: |


### PR DESCRIPTION
In my last PR, I saw a lot of warning because node16 is deprecated in actions. Hopefully it's okay to send a patch for this.
![CleanShot 2024-05-13 at 17 41 20@2x](https://github.com/input-output-hk/io-sim/assets/15181803/734733a3-d30c-48b6-b928-7df19a263527)

