### PR TITLE
Fix IOSimPOR test failure

### DIFF
--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Non breaking changes
 
 - Added `writeTMVar` to `MonadSTM` instance for `(IOSim s)`.
+- Fixes IOSimPOR test failure (see issue #154).
 
 ### Breaking changes
 

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -1786,7 +1786,7 @@ updateRaces thread@Thread { threadId = tid }
           if tid `notElem` concurrent
             then let
                   in stepInfo { stepInfoConcurrent = lessConcurrent
-                              , stepInfoNonDep = stepInfoNonDep'
+                              , stepInfoNonDep     = stepInfoNonDep'
                               }
 
             -- The core of IOSimPOR.  Detect if `newStep` is racing with any


### PR DESCRIPTION
we were missing updating the non-dependencies in the case where the thread is not concurrent. The thread is not concurrent so it makes sense to not discover any races but it still make sense to discover any non-dependencies to make sure we don't forget to include them as per our counterexample in #154 .