### PR TITLE
io-classes: added TBQueue test

### DIFF
--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -99,7 +99,7 @@ library
                        bytestring,
                        mtl   >=2.2 && <2.4,
                        primitive >= 0.7 && <0.11,
-                       stm   >=2.5 && <2.6,
+                       stm   >=2.5 && <2.5.2 || >=2.5.3 && <2.6,
                        time  >=1.9.1 && <1.13
   if impl(ghc >= 9.10)
     build-depends:     ghc-internal


### PR DESCRIPTION
stm-2.5.2.x comes with a bug. I added a test to cover it (#137), and
a constraint to avoid it.

This is related to haskell/stm#76.
