### PR TITLE
io-classes-1.6.0.0 release

### DIFF
--- a/io-classes/CHANGELOG.md
+++ b/io-classes/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revsion history of io-classes
 
-### Next version
+### 1.6.0.0
 
 ### Breaking changes
 

--- a/io-classes/README.md
+++ b/io-classes/README.md
@@ -16,18 +16,28 @@ We provide also non-standard extensions of this API in **sublibraries**:
   support of the [`nothunks`] library;
 * [`io-classes:strict-mvar`](https://input-output-hk.github.io/io-sim/io-classes/strict-mvar/index.html): strict `MVar`s
 * [`io-classes:si-timers`](https://input-output-hk.github.io/io-sim/io-classes/si-timers/index.html): timers api:
+
     - 32-bit safe API using `DiffTime` measured in seconds (rather than time in
       microseconds represented as `Int` as in `base`)
     - cancellable timeouts.
-* [`io-classes:mtl`](https://input-output-hk.github.io/io-sim/io-classes/io-classes-mtl/index.html): MTL instances.
 
-[`io-classes:strict-stm`](https://input-output-hk.github.io/io-sim/io-classes/strict-stm/index.html) and [`nothunks`] were successfully used in a large
+* [`io-classes:io-classes-mtl`](https://input-output-hk.github.io/io-sim/io-classes/io-classes-mtl/index.html):
+  MTL instances.
+
+[`io-classes:strict-stm`](https://input-output-hk.github.io/io-sim/io-classes/strict-stm/index.html)
+and [`nothunks`] were successfully used in a large
 code base to eliminate space leaks and keep that property over long development
 cycles.
 
 ## Documentation
 
-Hackage doesn't yet support public sublibraries, thus Haddocks are published [here][io-classes-haddocks]
+Hackage doesn't yet support public sublibraries, thus Haddocks are published
+[here][io-classes-haddocks].
+
+### Support material
+
+* [Philipp Kant (@kantp) at Bobconf 2022][bob-conf]
+* [Armando Santos (@bolt12) at ZuriHac 2022][zuriHac-2022]
 
 ## Exception Class Hierarchy
 
@@ -160,3 +170,6 @@ its limitations and so there might be some rough edges.  PRs are welcomed,
 [MonadST]: https://input-output-hk.github.io/io-sim/io-classes/Control-Monad-Class-MonadST.html#t:MonadST
 [MonadSay]: https://input-output-hk.github.io/io-sim/io-classes/Control-Monad-Class-MonadSay.html#t:MonadSay
 [io-classes-haddocks]: https://input-output-hk.github.io/io-sim
+
+[bob-conf]: https://youtu.be/uedUGeWN4ZM
+[zuriHac-2022]: https://youtu.be/tKIYQgJnGkA

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                io-classes
-version:             1.5.0.0
+version:             1.6.0.0
 synopsis:            Type classes for concurrency with STM, ST and timing
 description:
   IO Monad class hierarchy compatible with:
@@ -183,7 +183,6 @@ library si-timers
                        time              >=1.9.1 && <1.13,
 
                        io-classes:io-classes
-                                        ^>=1.5
   if flag(asserts)
      ghc-options:      -fno-ignore-asserts
 

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -3,13 +3,17 @@ name:                io-classes
 version:             1.5.0.0
 synopsis:            Type classes for concurrency with STM, ST and timing
 description:
-  IO Monad class hierarchy compatible with
-  [io-sim](https://hackage.haskell.org/package/io-sim),
-  [base](https://hackage.haskell.org/package/base),
-  [async](https://hackage.haskell.org/package/async),
-  [stm](https://hackage.haskell.org/package/stm),
-  [exceptions](https://hackage.haskell.org/package/exceptions) &
-  [time](https://hackage.haskell.org/package/time) packages.
+  IO Monad class hierarchy compatible with:
+
+    * [io-sim](https://hackage.haskell.org/package/io-sim),
+    * [base](https://hackage.haskell.org/package/base),
+    * [async](https://hackage.haskell.org/package/async),
+    * [stm](https://hackage.haskell.org/package/stm),
+    * [exceptions](https://hackage.haskell.org/package/exceptions) &
+    * [time](https://hackage.haskell.org/package/time)
+
+  packages.
+
 license:             Apache-2.0
 license-files:       LICENSE NOTICE
 copyright:           2019-2024 Input Output Global Inc (IOG)

--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history of io-sim
 
+## 1.6.0.0
+
+- Upgraded to `io-classes-1.6.0.0`
+
 ## 1.5.0.0
 
 ### Breaking changes

--- a/io-sim/README.md
+++ b/io-sim/README.md
@@ -2,7 +2,7 @@
 
 A pure simulator monad built on top of the lazy `ST` monad which supports:
 
-  * optional dynamic race discovery and schedule exploration
+  * optional dynamic race discovery and schedule exploration (see [`IOSimPOR`])
   * synchronous and asynchronous exceptions; including: throwing, catching and
     masking synchronous and asynchronous exceptions;
   * concurrency (using simulated threads), with interfaces shaped by the
@@ -15,7 +15,6 @@ A pure simulator monad built on top of the lazy `ST` monad which supports:
   * inspection of `STM` mutable data structures;
   * deadlock detection;
   * `MonadFix` instances for both [`IOSim`] and its corresponding `STM` monad.
-  * partial order reduction (see [`IOSimPOR`]).
 
 [`io-sim`] together with [`io-classes`] is a drop-in replacement for the `IO`
 monad (with some ramifications).  It was designed to write easily testable
@@ -42,7 +41,7 @@ also the other way around: that `GHC`s `STM` implementation meets the
 specification.
 
 [`io-sim`]:  https://hackage.haskell.org/package/io-sim
-[`io-classes`]: https://hackage.haskell.org/package/io-classes
-[`si-timers`]: https://hackage.haskell.org/package/si-timers
+[`io-classes`]: https://input-output-hk.github.io/io-sim/io-classes/index.html
+[`si-timers`]: https://input-output-hk.github.io/io-sim/io-classes/si-timers/index.html
 [`IOSimPOR`]: https://github.com/input-output-hk/io-sim/tree/main/io-sim/how-to-use-IOSimPOR.md
 [`IOSim`]: https://hackage.haskell.org/package/io-sim/docs/Control-Monad-IOSim.html#t:IOSim

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                io-sim
-version:             1.5.0.0
+version:             1.6.0.0
 synopsis:            A pure simulator for monadic concurrency with STM.
 description:
   A pure simulator monad with support of concurency (base & async style), stm,
@@ -77,7 +77,7 @@ library
                        TypeFamilies
   build-depends:       base              >=4.9 && <4.21,
                        io-classes:{io-classes,strict-stm,si-timers}
-                                        ^>=1.5,
+                                        ^>=1.6,
                        exceptions        >=0.10,
                        containers,
                        deepseq,


### PR DESCRIPTION
- **Updated README.md**
- **Bump io-classes & io-sim to `1.6.0.0`**
