### PR TITLE
Use cabal-version 3.4 in io-sim

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: ["CI"]
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "daily"
+

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.4
 name:                io-sim
-version:             1.6.0.0
+version:             1.6.0.1
 synopsis:            A pure simulator for monadic concurrency with STM.
 description:
   A pure simulator monad with support of concurrency (base & async style), stm,


### PR DESCRIPTION
* Use `cabal-version: 3.4` in `io-sim.cabal` file.
* Added `.github/dependabot.yml` configuration.