### PR TITLE
Attach label to TVars mentioned in Effects

### DIFF
--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## next version
 
 - Support `threadLabel` (`io-classes-1.8`)
+- `IOSimPOR`'s `Effect` traces now will correctly show labels on read/written
+  `TVars`.
 
 ## 1.6.0.0
 

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -58,7 +58,6 @@ module Control.Monad.IOSim.Types
   , ppTrace_
   , ppSimEvent
   , ppDebug
-  , Labelled (..)
   , module Control.Monad.IOSim.CommonTypes
   , Thrower (..)
   , Time (..)
@@ -1206,21 +1205,6 @@ ppSimEventType = \case
              ppVectorClock clock, " ",
              ppEffect eff ]
   EventRaces a -> show a
-
--- | A labelled value.
---
--- For example 'labelThread' or `labelTVar' will insert a label to `IOSimThreadId`
--- (or `TVarId`).
-data Labelled a = Labelled {
-    l_labelled :: !a,
-    l_label    :: !(Maybe String)
-  }
-  deriving (Eq, Ord, Generic)
-  deriving Show via Quiet (Labelled a)
-
-ppLabelled :: (a -> String) -> Labelled a -> String
-ppLabelled pp Labelled { l_labelled = a, l_label = Nothing  } = pp a
-ppLabelled pp Labelled { l_labelled = a, l_label = Just lbl } = concat ["Labelled ", pp a, " ", lbl]
 
 --
 -- Executing STM Transactions

--- a/io-sim/src/Control/Monad/IOSimPOR/Types.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Types.hs
@@ -38,8 +38,8 @@ import Control.Monad.IOSim.CommonTypes
 -- execution step.  Only used by *IOSimPOR*.
 --
 data Effect = Effect {
-    effectReads  :: !(Set TVarId),
-    effectWrites :: !(Set TVarId),
+    effectReads  :: !(Set (Labelled TVarId)),
+    effectWrites :: !(Set (Labelled TVarId)),
     effectForks  :: !(Set IOSimThreadId),
     effectThrows :: ![IOSimThreadId],
     effectWakeup :: !(Set IOSimThreadId)
@@ -50,11 +50,11 @@ ppEffect :: Effect -> String
 ppEffect Effect { effectReads, effectWrites, effectForks, effectThrows, effectWakeup } =
   "Effect { " ++
     concat (List.intersperse ", " $
-           [ "reads = "  ++ show effectReads  | not (null effectReads)  ]
-        ++ [ "writes = " ++ show effectWrites | not (null effectWrites) ]
-        ++ [ "forks = "  ++ ppList ppIOSimThreadId (Set.toList effectForks)  | not (null effectForks)  ]
-        ++ [ "throws = " ++ ppList ppIOSimThreadId             effectThrows  | not (null effectThrows) ]
-        ++ [ "wakeup = " ++ ppList ppIOSimThreadId (Set.toList effectWakeup) | not (null effectWakeup) ])
+           [ "reads = "  ++ ppList (ppLabelled show) (Set.toList effectReads)  | not (null effectReads)  ]
+        ++ [ "writes = " ++ ppList (ppLabelled show) (Set.toList effectWrites) | not (null effectWrites) ]
+        ++ [ "forks = "  ++ ppList ppIOSimThreadId (Set.toList effectForks)    | not (null effectForks)  ]
+        ++ [ "throws = " ++ ppList ppIOSimThreadId             effectThrows    | not (null effectThrows) ]
+        ++ [ "wakeup = " ++ ppList ppIOSimThreadId (Set.toList effectWakeup)   | not (null effectWakeup) ])
         ++ " }"
 
 
@@ -72,14 +72,14 @@ instance Monoid Effect where
 -- readEffect :: SomeTVar s -> Effect
 -- readEffect r = mempty{effectReads = Set.singleton $ someTvarId r }
 
-readEffects :: [SomeTVar s] -> Effect
-readEffects rs = mempty{effectReads = Set.fromList (map someTvarId rs)}
+readEffects :: [Labelled (SomeTVar s)] -> Effect
+readEffects rs = mempty{effectReads = Set.fromList (map (someTvarId <$>) rs)}
 
 -- writeEffect :: SomeTVar s -> Effect
 -- writeEffect r = mempty{effectWrites = Set.singleton $ someTvarId r }
 
-writeEffects :: [SomeTVar s] -> Effect
-writeEffects rs = mempty{effectWrites = Set.fromList (map someTvarId rs)}
+writeEffects :: [Labelled (SomeTVar s)] -> Effect
+writeEffects rs = mempty{effectWrites = Set.fromList (map (someTvarId <$>) rs)}
 
 forkEffect :: IOSimThreadId -> Effect
 forkEffect tid = mempty{effectForks = Set.singleton tid}


### PR DESCRIPTION
This ensures that `TxCommitted` events will also print labels in the `Effect`. Otherwise we get something like

```
TxCommitted [Labelled TVarId 0 SharedState] ... Effect { writes = [TVarId 0] }
```

now it will print:
```
TxCommitted [Labelled TVarId 0 SharedState] ... Effect { writes = [Labelled TVarId 0 SharedState] }
```