### PR TITLE
Improve `show` of `ScheduleMod`

### DIFF
--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Support `threadLabel` (`io-classes-1.8`)
 - `IOSimPOR`'s `Effect` traces now will correctly show labels on read/written
   `TVars`.
+- `Show` instance for `ScheduleMod` now prints `ThreadId`s in a slightly nicer
+  way, matching the way those steps would be traced in the `SimTrace`.
 
 ## 1.6.0.0
 

--- a/io-sim/src/Control/Monad/IOSimPOR/Types.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Types.hs
@@ -171,11 +171,12 @@ instance Show ScheduleMod where
   showsPrec d (ScheduleMod tgt ctrl insertion) =
     showParen (d>10) $
       showString "ScheduleMod " .
-      showsPrec 11 tgt .
+      showParen True (showString (ppStepId tgt)) .
       showString " " .
       showsPrec 11 ctrl .
-      showString " " .
-      showsPrec 11 insertion
+      showString " [" .
+      showString (List.intercalate "," (map ppStepId insertion)) .
+      showString "]"
 
 --
 -- Steps


### PR DESCRIPTION
Goes from this:

```
Schedule control: ControlAwait [ScheduleMod (RacyThreadId [2],1) ControlDefault [(RacyThreadId [1],0),(RacyThreadId [1],1)],ScheduleMod (RacyThreadId [2],5) ControlDefault [(RacyThreadId [1],4),(RacyThreadId [1],5),(ThreadId [],12),(ThreadId [],13),(ThreadId [],14),(RacyThreadId [1],6),(ThreadId [],15),(RacyThreadId [1],7),(RacyThreadId [1],8)]]
```

to this

```
Schedule control: ControlAwait [ScheduleMod (Thread {2}.1) ControlDefault [Thread {1}.0,Thread {1}.1],ScheduleMod (Thread {2}.5) ControlDefault [Thread {1}.4,Thread {1}.5,Thread [].12,Thread [].13,Thread [].14,Thread {1}.6,Thread [].15,Thread {1}.7,Thread {1}.8]]
```