### PR TITLE
Distinct TVarIds for various TVar roles

### DIFF
--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -8,6 +8,8 @@
 - `Show` instance for `ScheduleMod` now prints `ThreadId`s in a slightly nicer
   way, matching the way those steps would be traced in the `SimTrace`.
 - Implement `MonadLabelledMVar` instance for `(IOSim s)`
+- `TVarId` is now a sum type with one constructor per `TVar` role, e.g. `TVar`,
+  `TMVar`, `MVar` and a few others - except for `TChan`.
 
 ## 1.6.0.0
 

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -1236,9 +1236,8 @@ execNewTVar !tvarId !mbLabel x = do
     !tvarBlocked <- newSTRef ([], Set.empty)
     !tvarVClock  <- newSTRef $! VectorClock Map.empty
     !tvarTrace   <- newSTRef $! Nothing
-    return TVar {tvarId, tvarLabel,
-                 tvarCurrent, tvarUndo, tvarBlocked, tvarVClock,
-                 tvarTrace}
+    return TVar {tvarId, tvarLabel, tvarCurrent, tvarUndo, tvarBlocked,
+                 tvarVClock, tvarTrace}
 
 
 -- 'execReadTVar' is defined in `Control.Monad.IOSim.Type` and shared with /IOSimPOR/

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -149,7 +149,7 @@ data SimState s a = SimState {
        timers   :: !(Timeouts s),
        -- | list of clocks
        clocks   :: !(Map ClockId UTCTime),
-       nextVid  :: !TVarId,     -- ^ next unused 'TVarId'
+       nextVid  :: !VarId,     -- ^ next unused 'VarId'
        nextTmid :: !TimeoutId   -- ^ next unused 'TimeoutId'
      }
 
@@ -161,7 +161,7 @@ initialState =
       curTime  = Time 0,
       timers   = PSQ.empty,
       clocks   = Map.singleton (ClockId []) epoch1970,
-      nextVid  = TVarId 0,
+      nextVid  = 0,
       nextTmid = TimeoutId 0
     }
   where
@@ -358,7 +358,7 @@ schedule !thread@Thread{
       error "schedule: StartTimeout: Impossible happened"
 
     StartTimeout d action' k -> do
-      !lock <- TMVar <$> execNewTVar nextVid (Just $! "lock-" ++ show nextTmid) Nothing
+      !lock <- TMVar <$> execNewTVar (TMVarId nextVid) (Just $! "lock-" ++ show nextTmid) Nothing
       let !expiry    = d `addTime` time
           !timers'   = PSQ.insert nextTmid expiry (TimerTimeout tid nextTmid lock) timers
           !thread'   = thread { threadControl =
@@ -376,18 +376,18 @@ schedule !thread@Thread{
       schedule thread' simstate { timers = PSQ.delete tmid timers }
 
     RegisterDelay d k | d < 0 -> do
-      !tvar <- execNewTVar nextVid
+      !tvar <- execNewTVar (TVarId nextVid)
                           (Just $! "<<timeout " ++ show (unTimeoutId nextTmid) ++ ">>")
                           True
       let !expiry  = d `addTime` time
           !thread' = thread { threadControl = ThreadControl (k tvar) ctl }
       trace <- schedule thread' simstate { nextVid = succ nextVid }
-      return (SimTrace time tid tlbl (EventRegisterDelayCreated nextTmid nextVid expiry) $
+      return (SimTrace time tid tlbl (EventRegisterDelayCreated nextTmid (TVarId nextVid) expiry) $
               SimTrace time tid tlbl (EventRegisterDelayFired nextTmid) $
               trace)
 
     RegisterDelay d k -> do
-      !tvar <- execNewTVar nextVid
+      !tvar <- execNewTVar (TVarId nextVid)
                           (Just $! "<<timeout " ++ show (unTimeoutId nextTmid) ++ ">>")
                           False
       let !expiry  = d `addTime` time
@@ -397,7 +397,7 @@ schedule !thread@Thread{
                                          , nextVid  = succ nextVid
                                          , nextTmid = succ nextTmid }
       return (SimTrace time tid tlbl
-                (EventRegisterDelayCreated nextTmid nextVid expiry) trace)
+                (EventRegisterDelayCreated nextTmid (TVarId nextVid) expiry) trace)
 
     ThreadDelay d k | d < 0 -> do
       let !expiry    = d `addTime` time
@@ -424,12 +424,12 @@ schedule !thread@Thread{
           !expiry  = d `addTime` time
           !thread' = thread { threadControl = ThreadControl (k t) ctl }
       trace <- schedule thread' simstate { nextTmid = succ nextTmid }
-      return (SimTrace time tid tlbl (EventTimerCreated nextTmid nextVid expiry) $
+      return (SimTrace time tid tlbl (EventTimerCreated nextTmid (TVarId nextVid) expiry) $
               SimTrace time tid tlbl (EventTimerCancelled nextTmid) $
               trace)
 
     NewTimeout d k -> do
-      !tvar  <- execNewTVar nextVid
+      !tvar  <- execNewTVar (TVarId nextVid)
                            (Just $! "<<timeout-state " ++ show (unTimeoutId nextTmid) ++ ">>")
                            TimeoutPending
       let !expiry  = d `addTime` time
@@ -439,7 +439,7 @@ schedule !thread@Thread{
       trace <- schedule thread' simstate { timers   = timers'
                                          , nextVid  = succ nextVid
                                          , nextTmid = succ nextTmid }
-      return (SimTrace time tid tlbl (EventTimerCreated nextTmid nextVid expiry) trace)
+      return (SimTrace time tid tlbl (EventTimerCreated nextTmid (TVarId nextVid) expiry) trace)
 
     CancelTimeout (Timeout tvar tmid) k -> do
       let !timers' = PSQ.delete tmid timers
@@ -1030,7 +1030,7 @@ execAtomically :: forall s a c.
                   Time
                -> IOSimThreadId
                -> Maybe ThreadLabel
-               -> TVarId
+               -> VarId
                -> StmA s a
                -> (StmTxResult s a -> ST s (SimTrace c))
                -> ST s (SimTrace c)
@@ -1043,7 +1043,7 @@ execAtomically !time !tid !tlbl !nextVid0 !action0 !k0 =
        -> Map TVarId (SomeTVar s)  -- set of vars written
        -> [SomeTVar s]             -- vars written in order (no dups)
        -> [SomeTVar s]             -- vars created in order
-       -> TVarId                   -- var fresh name supply
+       -> VarId                   -- var fresh name supply
        -> StmA s b
        -> ST s (SimTrace c)
     go !ctl !read !written !writtenSeq !createdSeq !nextVid !action =
@@ -1145,8 +1145,8 @@ execAtomically !time !tid !tlbl !nextVid0 !action0 !k0 =
         let ctl' = BranchFrame (OrElseStmA b) k written writtenSeq createdSeq ctl
         go ctl' read Map.empty [] [] nextVid a
 
-      NewTVar !mbLabel x k -> do
-        !v <- execNewTVar nextVid mbLabel x
+      NewTVar mkId !mbLabel x k -> do
+        !v <- execNewTVar (mkId nextVid) mbLabel x
         go ctl read written writtenSeq (SomeTVar v : createdSeq) (succ nextVid) (k v)
 
       LabelTVar !label tvar k -> do
@@ -1229,14 +1229,14 @@ execAtomically' = go Map.empty
 
 
 execNewTVar :: TVarId -> Maybe String -> a -> ST s (TVar s a)
-execNewTVar nextVid !mbLabel x = do
+execNewTVar !tvarId !mbLabel x = do
     !tvarLabel   <- newSTRef mbLabel
     !tvarCurrent <- newSTRef x
     !tvarUndo    <- newSTRef $! []
     !tvarBlocked <- newSTRef ([], Set.empty)
     !tvarVClock  <- newSTRef $! VectorClock Map.empty
     !tvarTrace   <- newSTRef $! Nothing
-    return TVar {tvarId = nextVid, tvarLabel,
+    return TVar {tvarId, tvarLabel,
                  tvarCurrent, tvarUndo, tvarBlocked, tvarVClock,
                  tvarTrace}
 

--- a/io-sim/src/Control/Monad/IOSim/STM.hs
+++ b/io-sim/src/Control/Monad/IOSim/STM.hs
@@ -264,7 +264,7 @@ newEmptyMVarDefault = MVar <$> newTVarIO (MVarEmpty mempty mempty)
 labelMVarDefault
   :: MonadLabelledSTM m
   => MVarDefault m a -> String -> m ()
-labelMVarDefault (MVar tvar) = atomically . labelTVar tvar . (<> "-MVar")
+labelMVarDefault (MVar tvar) = atomically . labelTVar tvar
 
 newMVarDefault :: MonadSTM m => a -> m (MVarDefault m a)
 newMVarDefault a = MVar <$> newTVarIO (MVarFull a mempty)

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -561,8 +561,8 @@ schedule thread@Thread{
           timers' = PSQ.insert nextTmid expiry (Timer tvar) timers
           thread' = thread { threadControl = ThreadControl (k t) ctl }
       trace <- schedule thread' simstate { timers   = timers'
-                                          , nextVid  = succ (succ nextVid)
-                                          , nextTmid = succ nextTmid }
+                                         , nextVid  = succ (succ nextVid)
+                                         , nextTmid = succ nextTmid }
       return (SimPORTrace time tid tstep tlbl (EventTimerCreated nextTmid (TVarId nextVid) expiry) trace)
 
     CancelTimeout (Timeout tvar tmid) k -> do
@@ -1849,7 +1849,8 @@ normalizeRaces Races{ activeRaces, completeRaces } =
                         $ activeRaces
                         )
                      ++ completeRaces
-  in Races{ activeRaces = activeRaces', completeRaces = completeRaces' }
+  in Races{ activeRaces   = activeRaces',
+            completeRaces = completeRaces' }
 
 
 -- When a thread terminates, we remove it from the concurrent thread

--- a/io-sim/src/Control/Monad/IOSimPOR/Types.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Types.hs
@@ -69,14 +69,8 @@ instance Monoid Effect where
 -- Effect smart constructors
 --
 
--- readEffect :: SomeTVar s -> Effect
--- readEffect r = mempty{effectReads = Set.singleton $ someTvarId r }
-
 readEffects :: [Labelled (SomeTVar s)] -> Effect
 readEffects rs = mempty{effectReads = Set.fromList (map (someTvarId <$>) rs)}
-
--- writeEffect :: SomeTVar s -> Effect
--- writeEffect r = mempty{effectWrites = Set.singleton $ someTvarId r }
 
 writeEffects :: [Labelled (SomeTVar s)] -> Effect
 writeEffects rs = mempty{effectWrites = Set.fromList (map (someTvarId <$>) rs)}
@@ -224,11 +218,18 @@ data StepInfo = StepInfo {
 -- Races
 --
 
-data Races = Races { -- These steps may still race with future steps
-                     activeRaces   :: ![StepInfo],
-                     -- These steps cannot be concurrent with future steps
-                     completeRaces :: ![StepInfo]
-                   }
+-- | Information about all discovered races in a simulation categorised as
+-- active and complete races.
+--
+-- See 'normalizeRaces' how we split `StepInfo` into the two categories.
+--
+data Races = Races {
+    -- | These steps may still race with future steps.
+    activeRaces   :: ![StepInfo],
+
+    -- | These steps cannot be concurrent with future steps.
+    completeRaces :: ![StepInfo]
+  }
   deriving Show
 
 noRaces :: Races


### PR DESCRIPTION
`TVar`s are used to emulate `TMVar`s and `MVar`s and a few other shared variables, and thus can have
many different roles.  For each role `TVarId` provides a constructor,
which makes it easier to distinguish them in a trace.

* [x] `TVar`
* [x] `TMVar`
* [x] `MVar`
* [x] `TQueue`
* [x] `TBQueue`
* [x] `TSem`
* [ ] `TChan` - left as a todo.

```hs
ex0 :: IOSim s ()
ex0 = do
    atomically $ newTVar ""
    return ()

ex1 :: IOSim s ()
ex1 = do
    atomically $ newTMVar ""
    return ()

ex2 :: IOSim s ()
ex2 = do
    newEmptyMVar
    return ()
```

```
λ putStrLn  $ ppTrace $ runSimTrace ex0
0s - Thread []   main - TxCommitted [] [TVarId 0]
0s - Thread []   main - Unblocked []
0s - Thread []   main - Deschedule Yield
0s - Thread []   main - ThreadFinished
0s - Thread []   main - MainReturn () []
λ putStrLn  $ ppTrace $ runSimTrace ex1
0s - Thread []   main - TxCommitted [] [TMVarId 0]
0s - Thread []   main - Unblocked []
0s - Thread []   main - Deschedule Yield
0s - Thread []   main - ThreadFinished
0s - Thread []   main - MainReturn () []
λ putStrLn  $ ppTrace $ runSimTrace ex2
0s - Thread []   main - TxCommitted [] [MVarId 0]
0s - Thread []   main - Unblocked []
0s - Thread []   main - Deschedule Yield
0s - Thread []   main - ThreadFinished
0s - Thread []   main - MainReturn () []
```