### PR TITLE
Provide a exception-safe withTMVar combinator

### DIFF
--- a/io-classes/CHANGELOG.md
+++ b/io-classes/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Added `threadLabel` to `MonadThread`
 * Added `MonadLabelledMVar` class.
+* Added `withTMVar` and `withTMVarAnd` functions.
 
 ### 1.7.0.0
 

--- a/io-classes/src/Control/Concurrent/Class/MonadSTM/TMVar.hs
+++ b/io-classes/src/Control/Concurrent/Class/MonadSTM/TMVar.hs
@@ -18,6 +18,8 @@ module Control.Concurrent.Class.MonadSTM.TMVar
   , swapTMVar
   , writeTMVar
   , isEmptyTMVar
+  , withTMVar
+  , withTMVarAnd
     -- * MonadLabelledSTM
   , labelTMVar
   , labelTMVarIO


### PR DESCRIPTION
Also provide a default `traceTMVarShow` and `traceTVarShow` which use the `Show` constraint on the state to print standard messages.