### PR TITLE
Use IntPSQ instead of OrdPSQ for `timers` map.

### DIFF
--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -12,6 +12,8 @@
   `TMVar`, `MVar` and a few others - except for `TChan`.
 - A blocked `takeTVar` is now safe in the presence of exceptions. It will relay
   the value to other waiting threads.
+- Faster handling of timeouts and timers by using a more efficient
+  internal representation.
 
 ## 1.6.0.0
 

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -85,6 +85,7 @@ library
                        exceptions        >=0.10,
                        containers,
                        deepseq,
+                       hashable,
                        nothunks,
                        primitive         >=0.7 && <0.11,
                        psqueues          >=0.2 && <0.3,

--- a/io-sim/src/Control/Monad/IOSim/CommonTypes.hs
+++ b/io-sim/src/Control/Monad/IOSim/CommonTypes.hs
@@ -43,6 +43,7 @@ import Control.Monad.ST.Lazy
 
 import NoThunks.Class
 
+import Data.Hashable
 import Data.List (intercalate, intersperse)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -69,6 +70,8 @@ data IOSimThreadId =
   deriving stock    (Eq, Ord, Show, Generic)
   deriving anyclass NFData
   deriving anyclass NoThunks
+
+instance Hashable IOSimThreadId
 
 ppIOSimThreadId :: IOSimThreadId -> String
 ppIOSimThreadId (RacyThreadId as) = "Thread {"++ intercalate "," (map show as) ++"}"

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE CPP                       #-}
 {-# LANGUAGE DerivingVia               #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE FlexibleInstances         #-}
 {-# LANGUAGE GADTSyntax                #-}
 {-# LANGUAGE MultiParamTypeClasses     #-}

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -247,9 +247,6 @@ invariant Nothing SimState{runqueue,threads,clocks} =
     assert (PSQ.fold' (\(Down tid) _ _ a -> tid `Map.member` threads && a) True runqueue)
   . assert (and [ (isThreadBlocked t || isThreadDone t) == not (Down (threadId t) `PSQ.member` runqueue)
                 | t <- Map.elems threads ])
-  . assert (and (zipWith (\(Down tid, _, _) (Down tid', _, _) -> tid > tid')
-                         (PSQ.toList runqueue)
-                         (drop 1 (PSQ.toList runqueue))))
   . assert (and [ threadClockId t `Map.member` clocks
                 | t <- Map.elems threads ])
 

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -16,6 +16,7 @@
 -- incomplete uni patterns in 'schedule' (when interpreting 'StmTxCommitted')
 -- and 'reschedule'.
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 #if __GLASGOW_HASKELL__ >= 908
 -- We use partial functions from `Data.List`.
 {-# OPTIONS_GHC -Wno-x-partial #-}
@@ -53,16 +54,16 @@ import Prelude hiding (read)
 
 import Data.Dynamic
 import Data.Foldable (foldlM, traverse_)
+import Data.HashPSQ (HashPSQ)
+import Data.HashPSQ qualified as PSQ
+import Data.IntPSQ (IntPSQ)
+import Data.IntPSQ qualified as IPSQ
 import Data.List qualified as List
 import Data.List.Trace qualified as Trace
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Ord
-import Data.OrdPSQ (OrdPSQ)
-import Data.OrdPSQ qualified as PSQ
-import Data.IntPSQ (IntPSQ)
-import Data.IntPSQ qualified as IPSQ
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Time (UTCTime (..), fromGregorian)
@@ -87,7 +88,8 @@ import Control.Monad.IOSim.Types hiding (SimEvent (SimEvent), Trace (SimTrace))
 import Control.Monad.IOSim.Types (SimEvent)
 import Control.Monad.IOSimPOR.Timeout (unsafeTimeout)
 import Control.Monad.IOSimPOR.Types
-import Data.Coerce (coerce, Coercible)
+import Data.Coerce (Coercible, coerce)
+import Data.Hashable
 
 --
 -- Simulation interpreter
@@ -181,7 +183,9 @@ data TimerCompletionInfo s =
      -- ^ `timeout` timer run by `IOSimThreadId` which was assigned the given
      -- `TimeoutId` (only used to report in a trace).
 
-type RunQueue   = OrdPSQ (Down IOSimThreadId) (Down IOSimThreadId) ()
+instance Hashable a => Hashable (Down a)
+
+type RunQueue   = HashPSQ (Down IOSimThreadId) (Down IOSimThreadId) ()
 type Timeouts s = IntPSQ Time (TimerCompletionInfo s)
 
 -- | Internal state.


### PR DESCRIPTION
Using `IntPSQ` is much faster (20x) on some larger loads, and is recommended by `psqueues` where possible. 