### PR TITLE
`tryReadTBQueueDefault`: fix bug when returning `Nothing`

### DIFF
--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -23,6 +23,7 @@
   is more general.  These functions now accepts trace with any result, rather
   than one that finishes with `SimResult`.
 - More polymorphic `ppTrace_` type signature.
+- Fixed `tryReadTBQueue` when returning `Nothing`.
 
 ## 1.6.0.0
 

--- a/io-sim/src/Control/Monad/IOSim/STM.hs
+++ b/io-sim/src/Control/Monad/IOSim/STM.hs
@@ -149,9 +149,7 @@ tryReadTBQueueDefault (TBQueue queue _size) = do
       return (Just x)
     [] ->
       case reverse ys of
-        [] -> do
-          writeTVar queue $! (xs, r', ys, w)
-          return Nothing
+        [] -> return Nothing
 
         -- NB. lazy: we want the transaction to be
         -- short, otherwise it will conflict


### PR DESCRIPTION
Closes #195 

AFAICT, there is no need to update the state of the `TBQueue` when we didn't read anything.