### PR TITLE
coot/MArray instance fix

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -32,9 +32,9 @@ jobs:
     - name: Install LLVM (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install llvm@13
-        echo "LLVM_CONFIG=$(brew --prefix llvm@13)/bin/llvm-config" >> $GITHUB_ENV
-        echo "$(brew --prefix llvm@13)/bin" >> $GITHUB_PATH
+        brew install llvm@14
+        echo "LLVM_CONFIG=$(brew --prefix llvm@14)/bin/llvm-config" >> $GITHUB_ENV
+        echo "$(brew --prefix llvm@14)/bin" >> $GITHUB_PATH
 
     - name: Verify LLVM installation
       if: runner.os == 'macOS'

--- a/io-classes-mtl/CHANGELOG.md
+++ b/io-classes-mtl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Revision history for io-classes-mtl
 
+## 0.1.2.1
+
+### Non breaking changes
+
+* Added `newArray` to `MArray ContTSTM` instance  (all GHC versions `9.10` were
+  affected).
+
 ## 0.1.2.0
 
 ### Non breaking changes

--- a/io-classes-mtl/io-classes-mtl.cabal
+++ b/io-classes-mtl/io-classes-mtl.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               io-classes-mtl
-version:            0.1.2.0
+version:            0.1.2.1
 synopsis:           Experimental MTL instances for io-classes
 description:
     MTL instances for

--- a/io-classes-mtl/src/Control/Monad/Class/MonadSTM/Trans.hs
+++ b/io-classes-mtl/src/Control/Monad/Class/MonadSTM/Trans.hs
@@ -52,9 +52,7 @@ instance ( MonadSTM m, MArray e a (STM m) ) => MArray e a (ContTSTM r m) where
     getNumElements    = ContTSTM . getNumElements
     unsafeRead arr    = ContTSTM . unsafeRead arr
     unsafeWrite arr i = ContTSTM . unsafeWrite arr i
-#if __GLASGOW_HASKELL__ >= 910
     newArray idxs     = ContTSTM . newArray idxs
-#endif
 
 
 -- note: this (and the following) instance requires 'UndecidableInstances'

--- a/si-timers/si-timers.cabal
+++ b/si-timers/si-timers.cabal
@@ -8,7 +8,7 @@ description:
 license:             Apache-2.0
 license-files:       LICENSE NOTICE
 copyright:           2022-2024 Input Output Global Inc (IOG)
-author:              Duncan Coutts, Neil Davis, Marcin Szamotulski
+author:              Duncan Coutts, Neil Davies, Marcin Szamotulski
 maintainer:          Duncan Coutts duncan@well-typed.com, Marcin Szamotulski coot@coot.me
 category:            Time
 build-type:          Simple


### PR DESCRIPTION
Fixes from #202:

- **io-sim:test - refactored traceNoDuplicates**
- **io-classes-mtl: newArray for MArray ContTSTM instance**
- **gha: use llvm@14 on MacOS**
- **io-classes-0.1.2.1**
