### PR TITLE
Release io-classes-1.8

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10", "9.2", "9.4", "9.6", "9.8", "9.10", "9.12"]
+        ghc: ["9.6", "9.8", "9.10", "9.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     defaults:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6", "9.8", "9.10", "9.12"]
+        ghc: ["9.6.6", "9.8", "9.10", "9.12"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     defaults:
@@ -27,7 +27,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: "3.12.1.0"
+        cabal-version: "3.14.2.0"
 
     - name: Install LLVM (macOS)
       if: runner.os == 'macOS' && matrix.ghc == '8.10'

--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ package io-classes
 package strict-stm
   flags: +asserts
 
-if impl (ghc >= 9.12)
+if impl (ghc >= 9.10.2)
   allow-newer:
     -- Stuck on `cabal-3.14` issues and recalcitrant maintainers
     -- https://github.com/haskell/aeson/issues/1124

--- a/io-classes/CHANGELOG.md
+++ b/io-classes/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Revsion history of io-classes
 
-### next version
+### 1.8.0.0
 
 ### Breaking changes
 
-- Provided `MonadTraceMVar`
-- Renamed `InspectMonad` to `InspectMonadSTM`
+* Provided `MonadTraceMVar`
+* Renamed `InspectMonad` to `InspectMonadSTM`
 * Added `threadLabel` to `MonadThread`
 * Added `MonadLabelledMVar` class.
 * Added `labelMVar` to `Control.Concurrent.Class.MonadMVar.Strict`

--- a/io-classes/CHANGELOG.md
+++ b/io-classes/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ### next version
 
-* Support ghc-9.12
-
 ### Breaking changes
 
 - Provided `MonadTraceMVar`
@@ -21,6 +19,7 @@
 
 * Added monad transformer instances for `MonadInspectSTM` & `MonadTraceSTM`
   type classes.
+* Support ghc-9.12
 
 ### 1.7.0.0
 

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -87,31 +87,8 @@ library
                        Control.Monad.Class.MonadTime
                        Control.Monad.Class.MonadTimer
                        Control.Monad.Class.MonadTest
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
-  other-extensions:    CPP
-                       DataKinds
-                       DefaultSignatures
-                       DeriveFunctor
-                       DeriveGeneric
-                       DerivingStrategies
-                       ExistentialQuantification
-                       ExplicitNamespaces
-                       FlexibleContexts
-                       FlexibleInstances
-                       FunctionalDependencies
-                       GADTs
-                       GeneralisedNewtypeDeriving
-                       MultiParamTypeClasses
-                       NamedFieldPuns
-                       QuantifiedConstraints
-                       RankNTypes
-                       ScopedTypeVariables
-                       StandaloneDeriving
-                       TypeFamilies
-                       TypeFamilyDependencies
-                       TypeOperators
-                       UndecidableInstances
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base  >=4.9 && <4.22,
                        array,
                        async >=2.1,
@@ -138,8 +115,8 @@ library strict-stm
                        Control.Concurrent.Class.MonadSTM.Strict.TQueue
                        Control.Concurrent.Class.MonadSTM.Strict.TVar
   reexported-modules:  Control.Concurrent.Class.MonadSTM.TSem as Control.Concurrent.Class.MonadSTM.Strict.TSem
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base        >= 4.9 && <4.22,
                        array,
                        stm         >= 2.5 && <2.6,
@@ -161,8 +138,8 @@ library strict-mvar
   hs-source-dirs:      strict-mvar/src
 
   exposed-modules:     Control.Concurrent.Class.MonadMVar.Strict
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base        >= 4.9 && <4.22,
                        io-classes:io-classes,
   ghc-options:         -Wall
@@ -180,16 +157,8 @@ library si-timers
   exposed-modules:     Control.Monad.Class.MonadTime.SI
                        Control.Monad.Class.MonadTimer.SI
   other-modules:       Control.Monad.Class.MonadTimer.NonStandard
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
-  other-extensions:    BangPatterns,
-                       CPP,
-                       ConstraintKinds,
-                       DefaultSignatures,
-                       DeriveGeneric,
-                       NumericUnderscores,
-                       ScopedTypeVariables,
-                       TypeFamilies
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base              >=4.9 && <4.22,
                        deepseq,
                        mtl,
@@ -221,16 +190,16 @@ library mtl
                       io-classes:{io-classes,si-timers}
 
     hs-source-dirs:   mtl
-    default-language: Haskell2010
-    default-extensions:  ImportQualifiedPost
+    default-language: GHC2021
+    default-extensions: LambdaCase
 
 library testlib
   import:              warnings
   visibility:          public
   hs-source-dirs:      test
   exposed-modules:     Test.Control.Concurrent.Class.MonadMVar.Strict.WHNF
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base              >=4.9 && <4.22,
                        nothunks,
                        QuickCheck,
@@ -243,8 +212,8 @@ test-suite test-strict-mvar
   hs-source-dirs:      strict-mvar/test
   main-is:             Main.hs
 
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base,
                        QuickCheck,
                        tasty,
@@ -269,8 +238,8 @@ test-suite test-si-timers
   hs-source-dirs:      si-timers/test
   main-is:             Main.hs
   other-modules:       Test.MonadTimer
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base,
 
                        QuickCheck,

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.4
 name:                io-classes
-version:             1.7.0.0
+version:             1.8.0.0
 synopsis:            Type classes for concurrency with STM, ST and timing
 description:
   IO Monad class hierarchy compatible with:

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -104,6 +104,7 @@ library
     ghc-options: -fno-ignore-asserts
 
 library strict-stm
+  import:              warnings
   visibility:          public
   hs-source-dirs:      strict-stm
 
@@ -119,21 +120,14 @@ library strict-stm
   default-extensions:  LambdaCase
   build-depends:       base,
                        array,
-                       stm,
 
                        io-classes:io-classes,
-  ghc-options:         -Wall
-                       -Wno-unticked-promoted-constructors
-                       -Wcompat
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wpartial-fields
-                       -Widentities
 
   if flag(asserts)
     ghc-options: -fno-ignore-asserts
 
 library strict-mvar
+  import:              warnings
   visibility:          public
   hs-source-dirs:      strict-mvar/src
 
@@ -142,13 +136,6 @@ library strict-mvar
   default-extensions:  LambdaCase
   build-depends:       base,
                        io-classes:io-classes,
-  ghc-options:         -Wall
-                       -Wno-unticked-promoted-constructors
-                       -Wcompat
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wpartial-fields
-                       -Widentities
 
 library si-timers
   import:              warnings
@@ -208,10 +195,10 @@ library testlib
      ghc-options:      -fno-ignore-asserts
 
 test-suite test-strict-mvar
+  import:              warnings
   type:                exitcode-stdio-1.0
   hs-source-dirs:      strict-mvar/test
   main-is:             Main.hs
-
   default-language:    GHC2021
   default-extensions:  LambdaCase
   build-depends:       base,
@@ -219,15 +206,6 @@ test-suite test-strict-mvar
                        tasty,
                        tasty-quickcheck,
                        io-classes:testlib
-
-  ghc-options:         -Wall
-                       -Wno-unticked-promoted-constructors
-                       -Wcompat
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wpartial-fields
-                       -Widentities
-                       -fno-ignore-asserts
 
 -- Since `io-sim` depends on `si-times` (`io-sim` depends on `Time`) some tests of
 -- are in `io-sim:test`: this is a good enough reason to pull `io-sim:test`

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -91,11 +91,11 @@ library
   default-extensions:  LambdaCase
   build-depends:       base  >=4.9 && <4.22,
                        array,
-                       async >=2.1,
+                       async >=2.1 && <2.3,
                        bytestring,
                        mtl   >=2.2 && <2.4,
                        primitive >= 0.7 && <0.11,
-                       stm   >=2.5 && <2.5.2 || >=2.5.3 && <2.6,
+                       stm   >=2.5 && <2.5.2 || ^>=2.5.3,
                        time  >=1.9.1 && <1.13
   if impl(ghc >= 9.10)
     build-depends:     ghc-internal
@@ -117,9 +117,9 @@ library strict-stm
   reexported-modules:  Control.Concurrent.Class.MonadSTM.TSem as Control.Concurrent.Class.MonadSTM.Strict.TSem
   default-language:    GHC2021
   default-extensions:  LambdaCase
-  build-depends:       base        >= 4.9 && <4.22,
+  build-depends:       base,
                        array,
-                       stm         >= 2.5 && <2.6,
+                       stm,
 
                        io-classes:io-classes,
   ghc-options:         -Wall
@@ -140,7 +140,7 @@ library strict-mvar
   exposed-modules:     Control.Concurrent.Class.MonadMVar.Strict
   default-language:    GHC2021
   default-extensions:  LambdaCase
-  build-depends:       base        >= 4.9 && <4.22,
+  build-depends:       base,
                        io-classes:io-classes,
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors
@@ -159,12 +159,12 @@ library si-timers
   other-modules:       Control.Monad.Class.MonadTimer.NonStandard
   default-language:    GHC2021
   default-extensions:  LambdaCase
-  build-depends:       base              >=4.9 && <4.22,
+  build-depends:       base,
                        deepseq,
                        mtl,
                        nothunks,
                        stm,
-                       time              >=1.9.1 && <1.13,
+                       time,
 
                        io-classes:io-classes
   if flag(asserts)
@@ -183,7 +183,7 @@ library mtl
                    ,  Control.Monad.Class.MonadTime.SI.Trans
                    ,  Control.Monad.Class.MonadTimer.Trans
                    ,  Control.Monad.Class.MonadTimer.SI.Trans
-    build-depends:    base >=4.9 && <4.22,
+    build-depends:    base,
                       array,
                       mtl,
 
@@ -200,7 +200,7 @@ library testlib
   exposed-modules:     Test.Control.Concurrent.Class.MonadMVar.Strict.WHNF
   default-language:    GHC2021
   default-extensions:  LambdaCase
-  build-depends:       base              >=4.9 && <4.22,
+  build-depends:       base,
                        nothunks,
                        QuickCheck,
                        io-classes:strict-mvar

--- a/io-classes/io-classes.cabal
+++ b/io-classes/io-classes.cabal
@@ -38,7 +38,7 @@ category:            Control
 build-type:          Simple
 extra-doc-files:     CHANGELOG.md README.md strict-stm/README.md strict-mvar/README.md
 bug-reports:         https://github.com/input-output-hk/io-sim/issues
-tested-with:         GHC == { 8.10, 9.2, 9.4, 9.6, 9.8, 9.10 }
+tested-with:         GHC == { 9.6, 9.8, 9.10, 9.12 }
 
 source-repository head
   type:     git

--- a/io-classes/mtl/Control/Monad/Class/MonadSTM/Trans.hs
+++ b/io-classes/mtl/Control/Monad/Class/MonadSTM/Trans.hs
@@ -1,18 +1,10 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeApplications           #-}
-{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies          #-}
 
 -- undecidable instances needed for 'ContTSTM' instances of
 -- 'MonadThrow' and 'MonadCatch' type classes.
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-# OPTIONS_GHC -Wno-orphans            #-}
 
 module Control.Monad.Class.MonadSTM.Trans (ContTSTM (..)) where

--- a/io-classes/mtl/Control/Monad/Class/MonadThrow/Trans.hs
+++ b/io-classes/mtl/Control/Monad/Class/MonadThrow/Trans.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE CPP        #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Control.Monad.Class.MonadThrow.Trans () where
 

--- a/io-classes/si-timers/src/Control/Monad/Class/MonadTime/SI.hs
+++ b/io-classes/si-timers/src/Control/Monad/Class/MonadTime/SI.hs
@@ -1,9 +1,6 @@
-{-# LANGUAGE DefaultSignatures          #-}
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NumericUnderscores         #-}
+{-# LANGUAGE DefaultSignatures  #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Control.Monad.Class.MonadTime.SI
   ( MonadTime (..)

--- a/io-classes/si-timers/src/Control/Monad/Class/MonadTimer/SI.hs
+++ b/io-classes/si-timers/src/Control/Monad/Class/MonadTimer/SI.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE InstanceSigs        #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE NumericUnderscores  #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Control.Monad.Class.MonadTimer.SI
   ( -- * Type classes
     MonadDelay (..)

--- a/io-classes/src/Control/Concurrent/Class/MonadMVar.hs
+++ b/io-classes/src/Control/Concurrent/Class/MonadMVar.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DefaultSignatures      #-}
-{-# LANGUAGE FlexibleContexts       #-}
-{-# LANGUAGE QuantifiedConstraints  #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 
 module Control.Concurrent.Class.MonadMVar

--- a/io-classes/src/Control/Monad/Class/MonadAsync.hs
+++ b/io-classes/src/Control/Monad/Class/MonadAsync.hs
@@ -1,12 +1,7 @@
 {-# LANGUAGE CPP                    #-}
 {-# LANGUAGE DataKinds              #-}
 {-# LANGUAGE DefaultSignatures      #-}
-{-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE GADTs                  #-}
-{-# LANGUAGE MultiParamTypeClasses  #-}
-{-# LANGUAGE QuantifiedConstraints  #-}
-{-# LANGUAGE RankNTypes             #-}
-{-# LANGUAGE ScopedTypeVariables    #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 -- MonadAsync's ReaderT instance is undecidable.
 {-# LANGUAGE UndecidableInstances   #-}

--- a/io-classes/src/Control/Monad/Class/MonadFork.hs
+++ b/io-classes/src/Control/Monad/Class/MonadFork.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | A generalisation of
 -- <https://hackage.haskell.org/package/base/docs/Control-Concurrent.html Control.Concurrent>

--- a/io-classes/src/Control/Monad/Class/MonadST.hs
+++ b/io-classes/src/Control/Monad/Class/MonadST.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE InstanceSigs        #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 module Control.Monad.Class.MonadST (MonadST (..)) where
 
 import Control.Monad.Reader

--- a/io-classes/src/Control/Monad/Class/MonadSTM.hs
+++ b/io-classes/src/Control/Monad/Class/MonadSTM.hs
@@ -1,15 +1,11 @@
--- | This module corresponds to "Control.Monad.STM" in "stm" package
---
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DerivingStrategies    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE GADTs                #-}
 -- undecidable instances needed for 'WrappedSTM' instances of 'MonadThrow' and
 -- 'MonadCatch' type classes.
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | This module corresponds to "Control.Monad.STM" in "stm" package
+--
 module Control.Monad.Class.MonadSTM
   ( MonadSTM (STM, atomically, retry, orElse, check)
   , throwSTM

--- a/io-classes/src/Control/Monad/Class/MonadSTM/Internal.hs
+++ b/io-classes/src/Control/Monad/Class/MonadSTM/Internal.hs
@@ -1,23 +1,12 @@
-{-# LANGUAGE CPP                        #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DefaultSignatures          #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE PatternSynonyms            #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeFamilyDependencies     #-}
-{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE CPP                    #-}
+{-# LANGUAGE DefaultSignatures      #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE PatternSynonyms        #-}
+{-# LANGUAGE TypeFamilies           #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
 
 -- needed for `ReaderT` instance
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE UndecidableInstances   #-}
 
 -- Internal module.  It's only exposed as it provides various default types for
 -- defining new instances, otherwise prefer to use

--- a/io-classes/src/Control/Monad/Class/MonadThrow.hs
+++ b/io-classes/src/Control/Monad/Class/MonadThrow.hs
@@ -1,12 +1,6 @@
-{-# LANGUAGE CPP                       #-}
-{-# LANGUAGE DefaultSignatures         #-}
-{-# LANGUAGE DeriveFunctor             #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE StandaloneDeriving        #-}
-{-# LANGUAGE TupleSections             #-}
-{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 -- | A generalisation of
 -- <https://hackage.haskell.org/package/base/docs/Control-Exception.html Control.Exception>

--- a/io-classes/src/Control/Monad/Class/MonadTime.hs
+++ b/io-classes/src/Control/Monad/Class/MonadTime.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE DeriveGeneric #-}
-
 -- | <https://hackage.haskell.org/package/time time> and
 -- <https://hackage.haskell.org/package/base base> time API compatible with both
 -- 'IO' and <https://hackage.haskell.org/package/io-sim IOSim>.

--- a/io-classes/src/Control/Monad/Class/MonadTimer.hs
+++ b/io-classes/src/Control/Monad/Class/MonadTimer.hs
@@ -1,8 +1,5 @@
-{-# LANGUAGE DefaultSignatures   #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE FlexibleInstances   #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE TypeFamilies      #-}
 
 -- | Provides classes to handle delays and timeouts which generalised
 -- <https://hackage.haskell.org/package/base base> API to both 'IO' and

--- a/io-classes/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
+++ b/io-classes/strict-mvar/src/Control/Concurrent/Class/MonadMVar/Strict.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE BangPatterns  #-}
-{-# LANGUAGE TypeFamilies  #-}
-{-# LANGUAGE TypeOperators #-}
-
 -- | This module corresponds to "Control.Concurrent.MVar" in the @base@ package.
 module Control.Concurrent.Class.MonadMVar.Strict
   ( -- * StrictMVar

--- a/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TArray.hs
+++ b/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TArray.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE ExplicitNamespaces    #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | This module corresponds to `Control.Concurrent.STM.TArray` in "stm" package
 --

--- a/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TBQueue.hs
+++ b/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TBQueue.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE BangPatterns       #-}
-{-# LANGUAGE ExplicitNamespaces #-}
-{-# LANGUAGE GADTs              #-}
-{-# LANGUAGE TypeOperators      #-}
-
 -- | This module corresponds to `Control.Concurrent.STM.TBQueue` in "stm" package
 --
 module Control.Concurrent.Class.MonadSTM.Strict.TBQueue

--- a/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TChan.hs
+++ b/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TChan.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE BangPatterns       #-}
-{-# LANGUAGE ExplicitNamespaces #-}
-{-# LANGUAGE GADTs              #-}
-{-# LANGUAGE NamedFieldPuns     #-}
-{-# LANGUAGE TypeOperators      #-}
-
 -- | This module corresponds to `Control.Concurrent.STM.TChan` in "stm" package
 --
 module Control.Concurrent.Class.MonadSTM.Strict.TChan

--- a/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TMVar.hs
+++ b/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TMVar.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE BangPatterns       #-}
-{-# LANGUAGE ExplicitNamespaces #-}
-{-# LANGUAGE GADTs              #-}
-{-# LANGUAGE TypeOperators      #-}
-
 -- | This module corresponds to `Control.Concurrent.STM.TMVar` in "stm" package
 --
 module Control.Concurrent.Class.MonadSTM.Strict.TMVar

--- a/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TQueue.hs
+++ b/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TQueue.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE BangPatterns       #-}
-{-# LANGUAGE ExplicitNamespaces #-}
-{-# LANGUAGE GADTs              #-}
-{-# LANGUAGE NamedFieldPuns     #-}
-{-# LANGUAGE TypeOperators      #-}
-
 -- | This module corresponds to `Control.Concurrent.STM.TQueue` in "stm" package
 --
 module Control.Concurrent.Class.MonadSTM.Strict.TQueue

--- a/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TVar.hs
+++ b/io-classes/strict-stm/Control/Concurrent/Class/MonadSTM/Strict/TVar.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE BangPatterns   #-}
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE TypeFamilies   #-}
-{-# LANGUAGE TypeOperators  #-}
-
 -- | This module corresponds to `Control.Concurrent.STM.TVar` in "stm" package
 --
 module Control.Concurrent.Class.MonadSTM.Strict.TVar

--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Revision history of io-sim
 
-## next version
+## next release
+
+### Breaking changes
+
+### Non-breaking changes
+
+## 1.8.0.0
 
 - Provided `MonadTraceMVar`
 - Renamed `InspectMonad` to `InspectMonadSTM`

--- a/io-sim/bench/Main.hs
+++ b/io-sim/bench/Main.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Main (main) where
 
 import Control.Concurrent.Class.MonadSTM

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -60,25 +60,8 @@ library
                        Control.Monad.IOSimPOR.QuickCheckUtils,
                        Control.Monad.IOSimPOR.Timeout,
                        Data.Deque.Strict
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
-  other-extensions:    BangPatterns,
-                       CPP,
-                       DeriveFunctor,
-                       DeriveGeneric,
-                       DerivingVia,
-                       ExistentialQuantification,
-                       ExplicitNamespaces,
-                       FlexibleContexts,
-                       FlexibleInstances,
-                       GADTSyntax,
-                       GeneralizedNewtypeDeriving,
-                       MultiParamTypeClasses,
-                       NamedFieldPuns,
-                       NumericUnderscores,
-                       RankNTypes,
-                       ScopedTypeVariables,
-                       TypeFamilies
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base              >=4.9 && <4.22,
                        io-classes:{io-classes,strict-stm,si-timers}
                                         ^>=1.6 || ^>= 1.7 || ^>= 1.8,
@@ -109,8 +92,8 @@ test-suite test
                        Test.Control.Monad.Utils
                        Test.Control.Monad.IOSim
                        Test.Control.Monad.IOSimPOR
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base,
                        array,
                        containers,
@@ -131,8 +114,8 @@ benchmark bench
   type:                exitcode-stdio-1.0
   hs-source-dirs:      bench
   main-is:             Main.hs
-  default-language:    Haskell2010
-  default-extensions:  ImportQualifiedPost
+  default-language:    GHC2021
+  default-extensions:  LambdaCase
   build-depends:       base,
                        criterion ^>= 1.6,
 

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -19,7 +19,7 @@ category:            Testing
 build-type:          Simple
 extra-doc-files:     CHANGELOG.md README.md
 bug-reports:         https://github.com/input-output-hk/io-sim/issues
-tested-with:         GHC == { 8.10, 9.2, 9.4, 9.6, 9.8, 9.10 }
+tested-with:         GHC == { 9.6, 9.8, 9.10, 9.12 }
 
 flag asserts
   description: Enable assertions

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.4
 name:                io-sim
-version:             1.6.0.0
+version:             1.8.0.0
 synopsis:            A pure simulator for monadic concurrency with STM.
 description:
   A pure simulator monad with support of concurrency (base & async style), stm,
@@ -81,7 +81,7 @@ library
                        TypeFamilies
   build-depends:       base              >=4.9 && <4.22,
                        io-classes:{io-classes,strict-stm,si-timers}
-                                        ^>=1.6 || ^>= 1.7,
+                                        ^>=1.6 || ^>= 1.7 || ^>= 1.8,
                        exceptions        >=0.10,
                        containers,
                        deepseq,

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -1,11 +1,7 @@
 {-# LANGUAGE ExplicitNamespaces    #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 module Control.Monad.IOSim
   ( -- * Simulation monad
     IOSim

--- a/io-sim/src/Control/Monad/IOSim/CommonTypes.hs
+++ b/io-sim/src/Control/Monad/IOSim/CommonTypes.hs
@@ -1,11 +1,6 @@
-{-# LANGUAGE DeriveAnyClass             #-}
-{-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE DerivingVia                #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE DeriveAnyClass     #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia        #-}
 
 -- | Common types shared between `IOSim` and `IOSimPOR`.
 --

--- a/io-sim/src/Control/Monad/IOSim/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSim/Internal.hs
@@ -1,15 +1,6 @@
-{-# LANGUAGE BangPatterns              #-}
-{-# LANGUAGE CPP                       #-}
-{-# LANGUAGE DerivingVia               #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE GADTSyntax                #-}
-{-# LANGUAGE MultiParamTypeClasses     #-}
-{-# LANGUAGE NamedFieldPuns            #-}
-{-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE CPP          #-}
+{-# LANGUAGE DerivingVia  #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- incomplete uni patterns in 'schedule' (when interpreting 'StmTxCommitted')
 -- and 'reschedule'.

--- a/io-sim/src/Control/Monad/IOSim/InternalTypes.hs
+++ b/io-sim/src/Control/Monad/IOSim/InternalTypes.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs #-}
 
 -- | Internal types shared between `IOSim` and `IOSimPOR`.
 --

--- a/io-sim/src/Control/Monad/IOSim/STM.hs
+++ b/io-sim/src/Control/Monad/IOSim/STM.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE QuantifiedConstraints #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE TypeOperators         #-}
 
 -- | 'io-sim' implementation of 'TQueue', 'TBQueue' and 'MVar'.
 --

--- a/io-sim/src/Control/Monad/IOSim/Types.hs
+++ b/io-sim/src/Control/Monad/IOSim/Types.hs
@@ -1,20 +1,7 @@
-{-# LANGUAGE BangPatterns              #-}
-{-# LANGUAGE CPP                       #-}
-{-# LANGUAGE DeriveFunctor             #-}
-{-# LANGUAGE DeriveGeneric             #-}
-{-# LANGUAGE DerivingVia               #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE GADTSyntax                #-}
-{-# LANGUAGE InstanceSigs              #-}
-{-# LANGUAGE LambdaCase                #-}
-{-# LANGUAGE MultiParamTypeClasses     #-}
-{-# LANGUAGE NamedFieldPuns            #-}
-{-# LANGUAGE NumericUnderscores        #-}
-{-# LANGUAGE PatternSynonyms           #-}
-{-# LANGUAGE RankNTypes                #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE CPP             #-}
+{-# LANGUAGE DerivingVia     #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeFamilies    #-}
 
 -- Needed for `SimEvent` type.
 {-# OPTIONS_GHC -Wno-partial-fields    #-}

--- a/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Internal.hs
@@ -1,17 +1,8 @@
-{-# LANGUAGE BangPatterns              #-}
-{-# LANGUAGE CPP                       #-}
-{-# LANGUAGE DerivingVia               #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleContexts          #-}
-{-# LANGUAGE FlexibleInstances         #-}
-{-# LANGUAGE GADTSyntax                #-}
-{-# LANGUAGE MultiParamTypeClasses     #-}
-{-# LANGUAGE NamedFieldPuns            #-}
-{-# LANGUAGE RankNTypes                #-}
+{-# LANGUAGE CPP             #-}
+{-# LANGUAGE DerivingVia     #-}
 -- only used to construct records if its clear to do so
-{-# LANGUAGE RecordWildCards           #-}
-{-# LANGUAGE ScopedTypeVariables       #-}
-{-# LANGUAGE TypeFamilies              #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeFamilies    #-}
 
 -- incomplete uni patterns in 'schedule' (when interpreting 'StmTxCommitted')
 -- and 'reschedule'.

--- a/io-sim/src/Control/Monad/IOSimPOR/QuickCheckUtils.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/QuickCheckUtils.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
-
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Control.Monad.IOSimPOR.QuickCheckUtils where

--- a/io-sim/src/Control/Monad/IOSimPOR/Types.hs
+++ b/io-sim/src/Control/Monad/IOSimPOR/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 module Control.Monad.IOSimPOR.Types
   ( -- * Effects
     Effect (..)

--- a/io-sim/src/Data/Deque/Strict.hs
+++ b/io-sim/src/Data/Deque/Strict.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE CPP        #-}
-{-# LANGUAGE LambdaCase #-}
-
+{-# LANGUAGE CPP #-}
 -- | A minimal implementation of a strict deque.
 --
 module Data.Deque.Strict where

--- a/io-sim/src/Data/List/Trace.hs
+++ b/io-sim/src/Data/List/Trace.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE CPP           #-}
-{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE CPP #-}
 
 module Data.List.Trace
   ( Trace (..)

--- a/io-sim/test/Test/Control/Concurrent/Class/MonadMVar.hs
+++ b/io-sim/test/Test/Control/Concurrent/Class/MonadMVar.hs
@@ -1,7 +1,4 @@
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE GADTs #-}
 
 module Test.Control.Concurrent.Class.MonadMVar where
 

--- a/io-sim/test/Test/Control/Monad/IOSim.hs
+++ b/io-sim/test/Test/Control/Monad/IOSim.hs
@@ -1,10 +1,4 @@
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE ConstraintKinds     #-}
-{-# LANGUAGE DeriveFunctor       #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE NumericUnderscores  #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE CPP #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 

--- a/io-sim/test/Test/Control/Monad/IOSimPOR.hs
+++ b/io-sim/test/Test/Control/Monad/IOSimPOR.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE DeriveGeneric         #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE LambdaCase            #-}
-{-# LANGUAGE PartialTypeSignatures #-}
-{-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE CPP           #-}
+{-# LANGUAGE DeriveGeneric #-}
 
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}

--- a/io-sim/test/Test/Control/Monad/STM.hs
+++ b/io-sim/test/Test/Control/Monad/STM.hs
@@ -1,14 +1,7 @@
-{-# LANGUAGE BangPatterns               #-}
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE GADTs                      #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE NamedFieldPuns             #-}
-{-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE TypeOperators              #-}
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE GADTs              #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies       #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 

--- a/io-sim/test/Test/Control/Monad/Utils.hs
+++ b/io-sim/test/Test/Control/Monad/Utils.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-
 module Test.Control.Monad.Utils where
 
 import Data.Array


### PR DESCRIPTION
- **Reworded CHANGELOG.md**
- **io-classes: prefixed sublibraries**
- **Bump versions to 1.8.0.0**
