### PR TITLE
Support for `ghc-9.2` in `io-sim`

### DIFF
--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Non-breaking changes
 
+### 1.8.0.1
+
+* Added support for `ghc-9.2`.
+
 ## 1.8.0.0
 
 - Provided `MonadTraceMVar`

--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.4
 name:                io-sim
-version:             1.8.0.0
+version:             1.8.0.1
 synopsis:            A pure simulator for monadic concurrency with STM.
 description:
   A pure simulator monad with support of concurrency (base & async style), stm,
@@ -62,6 +62,8 @@ library
                        Data.Deque.Strict
   default-language:    GHC2021
   default-extensions:  LambdaCase
+  if impl(ghc < 9.4)
+    default-extensions: GADTs
   build-depends:       base              >=4.16 && <4.22,
                        io-classes:{io-classes,strict-stm,si-timers}
                                         ^>=1.6 || ^>= 1.7 || ^>= 1.8,
@@ -94,6 +96,8 @@ test-suite test
                        Test.Control.Monad.IOSimPOR
   default-language:    GHC2021
   default-extensions:  LambdaCase
+  if impl(ghc < 9.4)
+    default-extensions: GADTs
   build-depends:       base,
                        array,
                        containers,
@@ -116,6 +120,8 @@ benchmark bench
   main-is:             Main.hs
   default-language:    GHC2021
   default-extensions:  LambdaCase
+  if impl(ghc < 9.4)
+    default-extensions: GADTs
   build-depends:       base,
                        criterion ^>= 1.6,
 


### PR DESCRIPTION
This is a follow-up to https://github.com/input-output-hk/io-sim/pull/215 motivated by the build failures in `lsm-tree` (see https://github.com/IntersectMBO/lsm-tree/actions/runs/15419010635/job/43388792198?pr=749)