### PR TITLE
`io-sim-1.8` fails to build with `io-classes-1.7` and earlier versions

### DIFF
--- a/io-sim/io-sim.cabal
+++ b/io-sim/io-sim.cabal
@@ -66,7 +66,7 @@ library
     default-extensions: GADTs
   build-depends:       base              >=4.16 && <4.22,
                        io-classes:{io-classes,strict-stm,si-timers}
-                                        ^>=1.6 || ^>= 1.7 || ^>= 1.8,
+                                        ^>=1.8,
                        exceptions        >=0.10,
                        containers,
                        deepseq,


### PR DESCRIPTION
`InspectMonad` was renamed to `InspectMonadSTM` in `io-classes-1.8` and `io-sim-1.8`. `io-sim-1.8` therefore fails to build with `io-classes-1.7` and earlier, so those versions should be omitted from the build dependencies. Alternatively, some CPP could be added to use either `InspectMonad` or `InspectMonadSTM` depending on the version of `io-sim`.