### PR TITLE
Add IOSimPOR QuickCheck monadic combinators

### DIFF
--- a/io-sim/CHANGELOG.md
+++ b/io-sim/CHANGELOG.md
@@ -24,6 +24,8 @@
 * Added `Data.List.Trace.last`
 * Although `IOSim` and `IOSimPOR` are pure we use `evaluate` in a few places,
   non of them now catch asynchrounous exceptions.
+* Added `IOSimPOR` QuickCheck monadic combinators:
+  `monadicIOSimPOR`, `monadicIOSimPOR_` and `runIOSimPORGen`.
 
 ## 1.9.1.0
 

--- a/io-sim/src/Control/Monad/IOSim.hs
+++ b/io-sim/src/Control/Monad/IOSim.hs
@@ -18,6 +18,9 @@ module Control.Monad.IOSim
   , monadicIOSim
   , runIOSimGen
     -- ** Explore races using /IOSimPOR/
+  , monadicIOSimPOR_
+  , monadicIOSimPOR
+  , runIOSimPORGen
     -- $iosimpor
   , exploreSimTrace
   , controlSimTrace
@@ -801,3 +804,77 @@ runIOSimGen f sim = do
     Capture eval <- capture
     let trace = runSimTrace (eval sim)
     return (f trace)
+
+-- | Like <runSTGen
+-- https://hackage.haskell.org/package/QuickCheck-2.14.3/docs/Test-QuickCheck-Monadic.html#v:runSTGen>,
+-- but evaluates generated simulations using 'exploreSimTrace'.
+--
+-- The callback receives the previously passing trace (if any) and the current
+-- trace being checked.
+--
+-- @since 1.10.0.0
+--
+runIOSimPORGen :: Testable test
+               => (ExplorationOptions -> ExplorationOptions)
+               -> (Maybe (SimTrace a) -> SimTrace a -> test)
+               -> (forall s. Gen (IOSim s a))
+               -> Gen Property
+runIOSimPORGen optsf k sim = do
+  Capture eval <- capture
+  pure $ exploreSimTrace optsf (eval sim) k
+
+-- | A /IOSimPOR/ variant of 'monadicIOSim_', which:
+--
+-- * explores alternative schedules using 'exploreSimTrace';
+-- * allows to run in monad stacks build on top of `IOSim`;
+-- * gives more control how to attach debugging information to failed
+--   tests.
+--
+-- Note, to use this combinator your monad needs to be defined as:
+--
+-- > newtype M s a = M { runM :: ReaderT State (IOSim s) a }
+--
+-- It's important that `M s` is a monad.  For such a monad you'll need to
+-- provide a natural transformation:
+-- @
+--   -- the state could also be created as an `IOSim` computation.
+--   nat :: forall s a. State -> M s a -> 'IOSim' s a
+--   nat state m = runStateT (runM m) state
+-- @
+--
+-- @since 1.10.0.0
+--
+monadicIOSimPOR :: (Testable a, forall s. Monad (m s))
+                => (ExplorationOptions -> ExplorationOptions)
+                -> (Maybe (SimTrace Property) -> SimTrace Property -> Property)
+                -> (forall s a. m s a -> IOSim s a)
+                -> (forall s. PropertyM (m s) a)
+                -> Property
+monadicIOSimPOR optsf f tr sim =
+  property (runIOSimPORGen optsf f (tr <$> monadic' sim))
+
+-- | Like <monadicST
+-- https://hackage.haskell.org/package/QuickCheck-2.14.3/docs/Test-QuickCheck-Monadic.html#v:monadicST>,
+-- but using /IOSimPOR/ schedule exploration.
+--
+-- Note: it calls `traceResult` in non-strict mode, e.g. leaked threads do not
+-- cause failures.
+--
+-- > testProperty "example" $
+-- >   monadicIOSimPOR_ $ do
+-- >     x <- run (pure (1 :: Int))
+-- >     assert (x == 1)
+--
+-- @since 1.10.0.0
+--
+monadicIOSimPOR_ :: Testable a
+                 => (forall s. PropertyM (IOSim s) a)
+                 -> Property
+monadicIOSimPOR_ sim =
+   monadicIOSimPOR
+      id
+      (\_ tr -> case traceResult False tr of
+          Left e  -> counterexample (show e) False
+          Right p -> p)
+      id
+      sim

--- a/io-sim/test/Test/Control/Monad/IOSimPOR.hs
+++ b/io-sim/test/Test/Control/Monad/IOSimPOR.hs
@@ -45,6 +45,7 @@ import Test.Control.Monad.Utils
 
 import Data.List.Trace qualified as Trace
 import Test.QuickCheck
+import Test.QuickCheck.Monadic (assert, run)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck
 
@@ -122,6 +123,11 @@ tests =
 
       , testProperty "catch: throwTo async blocking (IOSim)"
       $ forall_masking_states unit_catch_throwTo_masking_state_async_mayblock_ST
+      ]
+    , testGroup "PropertyM callbacks"
+      [ testProperty "happy path"      unit_monadicIOSimPOR_0
+      , testProperty "failing assert"  unit_monadicIOSimPOR_1
+      , testProperty "exception"       unit_monadicIOSimPOR_2
       ]
     , testProperty "evaluate unit test" unit_evaluate_0
     , testGroup "forkIO unit tests"
@@ -756,6 +762,30 @@ unit_catch_6 =
                       say "after"
                    ) $ \_ trace ->
     selectTraceSay trace === ["inner", "handler1", "handler2", "after"]
+
+unit_monadicIOSimPOR_0, unit_monadicIOSimPOR_1, unit_monadicIOSimPOR_2
+  :: Property
+
+-- | Basic success case: a PropertyM test can be executed through IOSimPOR.
+unit_monadicIOSimPOR_0 =
+  monadicIOSimPOR_ $ do
+    x <- run (pure (1 :: Int))
+    assert (x == 1)
+
+-- | Failing assertions inside PropertyM are reported as property failures.
+unit_monadicIOSimPOR_1 =
+  expectFailure $
+    monadicIOSimPOR_ $ do
+      x <- run (pure (1 :: Int))
+      assert (x == 2)
+
+-- | Exceptions thrown by the simulation are turned into failing properties via
+-- `traceResult False`, matching the manual workaround from issue #229.
+unit_monadicIOSimPOR_2 =
+  expectFailure $
+    monadicIOSimPOR_ $ do
+      _ <- run $ evaluate (error "boom" :: ())
+      assert True
 
 -- evaluate should catch pure errors
 unit_evaluate_0 :: Property


### PR DESCRIPTION
Fixes #229

Add `IOSimPOR` QuickCheck monadic combinators:

- `monadicIOSimPOR`
- `monadicIOSimPOR_`
- `runIOSimPORGen`

similar to `monadicIOSim`, `monadicIOSim_`, and `runIOSimGen`.

This removes the need for hand-written `capture` + `exploreSimTrace`
plumbing when using `PropertyM` with `IOSimPOR`.

`runIOSimPORGen` keeps the callback shape of `exploreSimTrace`, rather
than `runIOSimGen`, to preserve the POR-specific callback power.

`monadicIOSimPOR_` provides a convenient default wrapper, similar to
`monadicIOSim_`.